### PR TITLE
New Problem: Poisson Regression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Vivak Patel <vivak.patel@wisc.edu>", "Christian Varner <cvarner@wisc
 version = "0.0.0"
 
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/examples/prob-PR_solve-fixedGD.jl
+++ b/examples/prob-PR_solve-fixedGD.jl
@@ -17,7 +17,7 @@ obj_evals = progData.counters.neval_obj
 # Compute objective values of different iterates for reporting purposes
 obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
 obj_term = OptimizationMethods.obj(progData, 
-    optData.iter_hist[optData.stop_iteration])
+    optData.iter_hist[optData.stop_iteration+1])
 
 
 
@@ -35,7 +35,7 @@ println(
 
     Terminal Iteration: $(optData.stop_iteration)
     Terminal Objective: $obj_term
-    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration])
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration+1])
 
     Objective Evaluations: $obj_evals
     Gradient Evaluations: $(progData.counters.neval_grad)

--- a/examples/prog-PR_solve-fixedGD.jl
+++ b/examples/prog-PR_solve-fixedGD.jl
@@ -1,0 +1,43 @@
+using OptimizationMethods
+
+progData = OptimizationMethods.PoissonRegression(Float64);
+optData = OptimizationMethods.FixedStepGD(
+    Float64, 
+    x0=randn(50), 
+    step_size=0.0005, 
+    threshold=1e-10, 
+    max_iterations=100
+)
+
+x = OptimizationMethods.fixed_step_gd(optData, progData);
+
+# Compute objective and residual evals during optimization 
+obj_evals = progData.counters.neval_obj
+
+# Compute objective values of different iterates for reporting purposes
+obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
+obj_term = OptimizationMethods.obj(progData, 
+    optData.iter_hist[optData.stop_iteration])
+
+
+
+println(
+"""
+    Problem: $(progData.meta.name)
+    Solver: $(optData.name)
+    Parameter Dimension: $(progData.meta.nvar)
+    
+    Max Iterations Allowed: $(optData.max_iterations)
+    Gradient Stopping Threshold: $(optData.threshold)
+
+    Initial Objective: $obj_init
+    Initial Grad Norm: $(optData.grad_val_hist[1])
+
+    Terminal Iteration: $(optData.stop_iteration)
+    Terminal Objective: $obj_term
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration])
+
+    Objective Evaluations: $obj_evals
+    Gradient Evaluations: $(progData.counters.neval_grad)
+"""
+)

--- a/src/OptimizationMethods.jl
+++ b/src/OptimizationMethods.jl
@@ -3,6 +3,7 @@ module OptimizationMethods
 # Dependencies
 using LinearAlgebra
 using NLPModels
+using Distributions
 
 ################################################################################
 # Optimization Problems 
@@ -25,6 +26,7 @@ abstract type AbstractProblemAllocate{T} end
 
 ## Source Code
 include("problems/gaussian_least_squares.jl")
+include("problems/poisson_regression.jl")
 
 
 ################################################################################

--- a/src/problems/poisson_regression.jl
+++ b/src/problems/poisson_regression.jl
@@ -6,14 +6,15 @@
 """
     PoissonRegression{T, S} <: AbstractNLPModel{T, S}
 
-Implements poisson regression with the canonical link function. If the design
-matrix (i.e., the covariates) and responses are not supplied, they are randomly generated. 
+Implements Poisson regression with the canonical link function. If the design
+    matrix (i.e., the covariates) and responses are not supplied, they are 
+    randomly generated. 
 
 # Objective Function
 
 Let ``A`` be the design matrix, and ``b`` be the responses. Each row of ``A``
-and corresponding entry in ``b`` are the predictor and observation from one
-experimental unit. The entries in ``b`` must be integer valued and non-negative.
+    and corresponding entry in ``b`` are the predictor and observation from one 
+    unit. The entries in ``b`` must be integer valued and non-negative.
 
 Let ``A_i`` be row ``i`` of ``A`` and ``b_i`` entry ``i`` of ``b``. Let
 ```math
@@ -21,20 +22,23 @@ Let ``A_i`` be row ``i`` of ``A`` and ``b_i`` entry ``i`` of ``b``. Let
 ```
 
 Let ``n`` be the number of rows of ``A`` (i.e., number of observations), then
-the negative log-likelihood of the data is under the model is 
+    the negative log-likelihood of the model is 
 ```math
 \\sum_{i=1}^n \\mu_i(x) - b_i (A_i^\\intercal x) + C(b),
 ```
-where ``C(b)`` is a constant depending on the data. We implement the objective function
-to be the negative log-likelihood up to the constant term ``C(b)``. That is,
+where ``C(b)`` is a constant depending on the data. We implement the objective  
+    function to be the negative log-likelihood up to the constant term ``C(b)``. 
+    That is,
 ```math
-\\sum_{i=1}^n \\mu_i(x) - b_i (A_i^\\intercal x).
+F(x) = \\sum_{i=1}^n \\mu_i(x) - b_i (A_i^\\intercal x).
 ```
 
 # Fields
 
-- `meta::NLPModelMeta{T, S}`, NLPModel struct for storing meta information for the problem
-- `counters::Counters`, NLPModel Counter struct that provides evaluations tracking.
+- `meta::NLPModelMeta{T, S}`, NLPModel struct for storing meta information for 
+    the problem
+- `counters::Counters`, NLPModel Counter struct that provides evaluations 
+    tracking.
 - `design::Matrix{T}`, covariate matrix for the problem/experiment (``A``).
 - `response::Vector{T}`, observations for the problem/experiment (``b``).
 
@@ -42,26 +46,28 @@ to be the negative log-likelihood up to the constant term ``C(b)``. That is,
 
     PoissonRegression(::Type{T}; nobs::Int64 = 1000, nvar::Int64 = 50) where {T}
 
-Construct the `struct` for PoissonRegression when simulated data is needed. 
-The design matrix (``A``) and response vector ``b`` are randomly generated as follows. 
-For the design matrix, the first column is all ones, and the rest are generated according 
-to a normal distribution where each column has been normalized to have unit variance. 
-For the response vector, let ``\\beta`` be the "true" relationship between the covariates
-and response vector for the poisson regression model, then the ``i``th entry of the 
-response vector is generated from a Poisson Distribution with rate parameter 
-``\\exp(A_i^\\intercal \\beta)``.
+Construct the `struct` for Poisson Regression when simulated data is needed. 
+    The design matrix (``A``) and response vector ``b`` are randomly generated 
+    as follows. 
+    For the design matrix, the first column is all ones, and the rest are
+    generated according to a normal distribution where each column has been 
+    normalized to have unit variance. 
+    For the response vector, let ``\\beta`` be the "true" relationship between 
+    the covariates and response vector for the poisson regression model, 
+    then the ``i``th entry of the response vector is generated from a Poisson 
+    Distribution with rate parameter ``\\exp(A_i^\\intercal \\beta)``.
 
     PoissonRegression(design::Matrix{T}, response::Vector{T}; 
-    x0::Vector{T} = zeros(T, size(design)[2])) where {T}
+        x0::Vector{T} = zeros(T, size(design)[2])) where {T}
 
-Constructs the `struct` PoissonRegression when the design matrix and response vector
-are known. The initial guess, `x0` is a keyword argument that is set to all
-zeros by default. 
+Constructs the `struct` for Poisson Regression when the design matrix and response 
+    vector are known. The initial guess, `x0` is a keyword argument that is set 
+    to all zeros by default. 
 
 !!! Remark
-    When using this constructor, the number of rows of `design` must be equal to the size
-    of response. When providing `x0`, the number of entries must be the same as the number
-    of columns in `design`.
+    When using this constructor, the number of rows of `design` must be equal to 
+    the size of response. When providing `x0`, the number of entries must be the 
+    same as the number of columns in `design`.
 """
 mutable struct PoissonRegression{T, S} <: AbstractNLPModel{T, S}
     meta::NLPModelMeta{T, S}
@@ -73,7 +79,7 @@ function PoissonRegression(
     ::Type{T};
     nobs::Int64 = 1000,
     nvar::Int64 = 50
-) where {T}
+) where T
     
     # error checking
     @assert nobs > 0 "`nobs` is non-zero or negative"

--- a/src/problems/poisson_regression.jl
+++ b/src/problems/poisson_regression.jl
@@ -33,6 +33,10 @@ where ``C(b)`` is a constant depending on the data. We implement the objective
 F(x) = \\sum_{i=1}^n \\mu_i(x) - b_i (A_i^\\intercal x).
 ```
 
+!!! Remark
+    Because the additive term ``C(b)`` is not included in the objective function,
+    the objective function can take on negative values.
+
 # Fields
 
 - `meta::NLPModelMeta{T, S}`, NLPModel struct for storing meta information for 

--- a/src/problems/poisson_regression.jl
+++ b/src/problems/poisson_regression.jl
@@ -170,7 +170,7 @@ Requests memory for `obs_obs_t` which is an `nobs` by `nvar` by `nvar` tensor,
     and computes the outer produce for each row of `A`. Returns the structure.
 """
 struct PrecomputePoissReg{T} <: AbstractPrecompute{T}
-    obs_obs_t::Array{Float64, 3}
+    obs_obs_t::Array{T, 3}
 end
 function PrecomputePoissReg(
     progData::PoissonRegression{T, S}
@@ -478,8 +478,7 @@ args = [
     """
     function NLPModels.objgrad!($(args...); recompute::Bool = true) where {T, S}
         NLPModels.grad!(progData, precomp, store, x; recompute = recompute)
-        o = NLPModels.obj(progData, precomp, store, x; recompute = false)
-        return o
+        return NLPModels.obj(progData, precomp, store, x; recompute = false)
     end
 
     @doc """

--- a/src/problems/poisson_regression.jl
+++ b/src/problems/poisson_regression.jl
@@ -503,6 +503,7 @@ args = [
             store.predicted_rates .= exp.(store.linear_effect)
         end
 
+        fill!(store.hess, 0)
         n = size(progData.design, 1)
         for i in 1:n
             store.hess .+= store.predicted_rates[i] .* view(precomp.obs_obs_t, i, :, :) 

--- a/src/problems/poisson_regression.jl
+++ b/src/problems/poisson_regression.jl
@@ -1,0 +1,122 @@
+# Date: 10/05/2024
+# Author: Christian Varner
+# Purpose: Implementation of Poisson regression with a canonical link function.
+
+# NLPModel struct
+"""
+"""
+mutable struct PoissonRegression{T, S} <: AbstractNLPModel{T, S}
+    meta::NLPModelMeta{T, S}
+    counters::Counters
+    design::Matrix{T}
+    response::Vector{T}
+end
+function PoissonRegression(
+    ::Type{T};
+    nobs::Int64 = 1000,
+    nvar::Int64 = 50
+) where {T}
+    # initialize the meta
+    meta = NLPModelMeta(
+        nvar = nvar,
+        name = "Poisson Regression w/ Canonical Link",
+        x0 = zeros(T, nvar)
+    )
+
+    # initialize the counters
+    counters = Counters()
+
+    # initialize the design matrix
+    design = hcat(ones(T, nobs), randn(T, nobs, nvar-1) ./ T(sqrt(nvar - 1)))
+
+    # create the responses
+    ## initialization of coefficient vector -- note this might note
+    ## be the optimal solution to the optimization problem
+    β = randn(T, nvar)
+
+    ## generate data
+    poisson_dist = Distributions.Poisson{T}
+    λ = exp.(design * β)
+    response = Vector{T}([rand(poisson_dist(λ[i])) for i in 1:nobs])
+
+    # return the poisson regression struct
+    return PoissonRegression(
+        meta, 
+        counters,
+        design,
+        response
+    )
+end
+function PoissonRegression(
+    design::Matrix{T},
+    response::Vector{T};
+    x0::Vector{T} = zeros(T, size(design)[2])
+) where {T}
+    # initialize meta
+    meta = NLPModelMeta(
+        name = nvar,
+        name = "Poisson Regression w/ Canonical Link",
+        x0 = x0
+    )
+
+    # initialize counters
+    counters = Counters()
+
+    # return the struct
+    return PoissonRegression(
+        meta,
+        counters,
+        design,
+        response
+    )
+end
+
+# Precomputed struct -- it might be useful at some point to allows things to control computed memory
+struct PrecomputePoissReg{T} <: AbstractPrecompute{T}
+    coef_coef_t::Matrix{T}
+end
+function PrecomputePoissReg(
+    progData::PoissonRegression{T, S}
+) where {T, S}
+
+    # design matrix
+    coef = progData.design
+    nobs, nvar = size(coef)
+    
+    # for hessian calculation
+    coef_coef_t = zeros(T, nobs, nvar, nvar)
+    for i in 1:n
+        coef_coef_t = coef[i] .* coef[i]'
+    end
+end
+
+# Allocated memory struct
+struct AllocatePoissReg{T} <: AbstractProblemAllocate{T}
+    linear_effect::Vector{T}
+    predicted_rates::Vector{T}
+    residuals::Vector{T}
+    grad::Vector{T}
+    hess::Matrix{T}
+end
+function AllocatePoissReg(
+    progData::PoissonRegression{T, S}
+) where {T, S}
+    nobs = size(progData.coef)[1]
+    nvar = size(progData.coef)[2]
+
+    return AllocatePoissReg(
+        zeros(T, nobs),
+        zeros(T, nobs),
+        zeros(T, nobs),
+        zeros(T, nvar),
+        zeros(T, nvar, nvar)
+    )
+end
+
+# Functionality
+
+## operations without precomputed and allocated memory
+
+## operations with precomputed and without allocated memory
+
+## operations with precompute and allocated memory

--- a/test/problems/logistic_regression.jl
+++ b/test/problems/logistic_regression.jl
@@ -2,7 +2,7 @@
 # Author: Christian Varner
 # Purpose: Implement some test cases for logistic regression
 
-module TestPoissonRegression
+module TestLogisticRegression
 
 using Test, ForwardDiff, OptimizationMethods, Random, LinearAlgebra, NLPModels
 

--- a/test/problems/poisson_regression.jl
+++ b/test/problems/poisson_regression.jl
@@ -1,0 +1,48 @@
+# OptimizationMethods.jl 
+
+module TestPoissonRegression 
+
+using Test, ForwardDiff, OptimizationMethods, Random
+
+@testset "Problem: Poission Regression" begin
+
+    # set the seed for reproducibility
+    Random.seed(1010)
+
+    ####################################
+    # Test Struct: Poisson Regression
+    ####################################
+
+    # Check if struct is defined 
+    @test isdefined(OptimizationMethods, :PoissonRegression)
+
+    # Test Super type 
+    @test supertype(OptimizationMethods.PoissonRegression) == AbstractNLPModel
+
+    # Test Fields 
+    for name in [:meta, :counters, :design, :response]
+        @test name in fieldnames(OptimizationMethods.PoissonRegression)
+    end
+
+    ####################################
+    # Test constructors
+    ####################################
+
+    real_types = [Float16, Float32, Float64]
+
+    for real_type in real_types
+        #Check Assertions 
+        @test_throws AssertionError OptimizationMethods.PoissonRegression(
+            real_type, nobs=-1, nvar=50)
+        @test_throws AssertionError OptimizationMethods.PoissonRegression(
+            real_type, nobs=1000, nvar=-1)
+
+        #Generate Random Problem
+        progData = OptimizationMethods.PoissonRegression(real_type)
+        
+        #TODO: What are sensible tests for a constructor
+    end
+
+end
+
+end

--- a/test/problems/poisson_regression.jl
+++ b/test/problems/poisson_regression.jl
@@ -2,7 +2,7 @@
 
 module TestPoissonRegression 
 
-using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
+using Test, ForwardDiff, OptimizationMethods, Random, NLPModels, LinearAlgebra
 
 @testset "Problem: Poission Regression" begin
 
@@ -184,7 +184,7 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
     ####################################
     # Test Methods 
     ####################################
-    real_types = [Float16, Float32, Float64]
+    real_types = [Float32, Float64] # TODO: Float16 causes problems
     nobs_default = 1000 
     nvar_default = 50 
     nargs = 10
@@ -194,7 +194,7 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
         progData = OptimizationMethods.PoissonRegression(real_type)
         precomp, store =  OptimizationMethods.initialize(progData)
         arg_tests = [randn(real_type, nvar_default) / real_type(sqrt(nvar_default)) 
-            for i =1:nargs]
+            for i = 1:nargs]
 
         nevals_obj = 1
         nevals_grad = 1 
@@ -232,19 +232,19 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
         for x in arg_tests
             g = ForwardDiff.gradient(objective, x)
 
-            #TODO: Produces Error 
-            #$@test g ≈ OptimizationMethods.grad(progData, x)
-            #@test progData.counters.neval_grad == nevals_grad 
-            #nevals_grad += 1
+            #TODO: Produces Error for Float16
+            @test g ≈ OptimizationMethods.grad(progData, x)
+            @test progData.counters.neval_grad == nevals_grad 
+            nevals_grad += 1
 
-            #TODO: Produces Error
-            #@test g ≈ OptimizationMethods.grad(progData, precomp, x)
-            #@test progData.counters.neval_grad == nevals_grad 
-            #nevals_grad += 1
+            #TODO: Produces Error for Float16
+            @test g ≈ OptimizationMethods.grad(progData, precomp, x)
+            @test progData.counters.neval_grad == nevals_grad 
+            nevals_grad += 1
 
             OptimizationMethods.grad!(progData, precomp, store, x)
-            #TODO: Produces Error 
-            #@test g ≈ store.grad
+            #TODO: Produces Error for Float16
+            @test g ≈ store.grad
             @test progData.counters.neval_grad == nevals_grad 
             nevals_grad += 1
         end
@@ -259,8 +259,8 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
             # Without Precomputation 
             o, g = OptimizationMethods.objgrad(progData, x)
             @test o ≈ obj
-            #TODO: Produces Error 
-            #@test g ≈ gra
+            #TODO: Produces Error for Float16
+            @test g ≈ gra
             @test progData.counters.neval_obj == nevals_obj 
             @test progData.counters.neval_grad == nevals_grad 
             nevals_obj += 1
@@ -270,8 +270,8 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
             # With Precomputation 
             o, g = OptimizationMethods.objgrad(progData, precomp, x)
             @test o ≈ obj 
-            #TODO: Produces error 
-            #@test g ≈ gra
+            #TODO: Produces error for Float16
+            @test g ≈ gra
             @test progData.counters.neval_obj == nevals_obj 
             @test progData.counters.neval_grad == nevals_grad 
             nevals_obj += 1
@@ -281,8 +281,8 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
             # With Precomputation and Allocation 
             o = OptimizationMethods.objgrad!(progData, precomp, store, x)
             @test o ≈ obj
-            #TODO: Produces Error 
-            #@test store.grad ≈ gra
+            #TODO: Produces Error for Float16 
+            @test store.grad ≈ gra
             @test progData.counters.neval_obj == nevals_obj 
             @test progData.counters.neval_grad == nevals_grad 
             nevals_obj += 1
@@ -307,11 +307,10 @@ using Test, ForwardDiff, OptimizationMethods, Random, NLPModels
             nevals_hess += 1
 
             # With Precomputation and Allocation 
-            #TODO: Produces Errors 
-            #OptimizationMethods.hess!(progData, precomp, store, x)
-            #@test h ≈ store.hess
-            #@test progData.counters.neval_hess == nevals_hess 
-            #nevals_hess += 1
+            OptimizationMethods.hess!(progData, precomp, store, x)
+            @test h ≈ store.hess
+            @test progData.counters.neval_hess == nevals_hess 
+            nevals_hess += 1
         end
     end
 end

--- a/test/test.txt
+++ b/test/test.txt
@@ -1,5 +1,6 @@
 problems/gaussian_least_squares.jl
 problems/logistic_regression.jl
+problems/poisson_regression.jl
 methods/gd_fixed.jl
 methods/gd_barzilai_borwein.jl
 methods/gd_lipschitz_approximation.jl


### PR DESCRIPTION
# Summary

An implementation of the negative log-likelihood (and its derivatives) for Poisson regression with canonical link. The Poisson regression problem can use user-supplied design and response. If none are provided, a random design and response are generated.

Closes #14 

# Specifics

- Includes problem implementation using NLPModels format
- Includes additional precomputation and storage structs
- Includes objective, gradient, objective-gradient and Hessian implementations
- Provides tests for all of these structures and methods
- Includes an example for solving the Poisson Regression problem using fixed step size gradient descent

# Notes
- The name of the logistic regression test module was incorrectly named after the Poisson regression. This commit also fixes this issue. 
- Some tests are failing for `Float16`. These have been removed. 