### PR TITLE
Renaming GaussianLeastSquares to LeastSquares, and new constructor for LeastSquares

### DIFF
--- a/examples/prob-LS_solve-LipschitzApproxGD.jl
+++ b/examples/prob-LS_solve-LipschitzApproxGD.jl
@@ -1,19 +1,20 @@
+# Date: 10/04/2024
+# Author: Christian Varner
+# Purpose: Implement an example of running lipschitz_approximation_gd() on 
+# an instance of GaussianLeastSquares.
+
 using OptimizationMethods
 
-progData = OptimizationMethods.GaussianLeastSquares(Float64)
-optData = BarzilaiBorweinGD(
-    Float64,
-    x0 = randn(50),
-    init_stepsize = 1e-5,
-    long_stepsize = true,
-    threshold = 1e-10,
-    max_iterations = 100
+progData = OptimizationMethods.LeastSquares(Float64);
+optData = OptimizationMethods.LipschitzApproxGD(
+    Float64, 
+    x0=randn(50), 
+    init_stepsize=0.0005, 
+    threshold=1e-10, 
+    max_iterations=100
 )
 
-x = barzilai_borwein_gd(
-    optData,
-    progData
-)
+x = OptimizationMethods.lipschitz_approximation_gd(optData, progData);
 
 # Compute objective and residual evals during optimization 
 obj_evals = progData.counters.neval_obj
@@ -22,7 +23,8 @@ res_evals = progData.counters.neval_residual
 # Compute objective values of different iterates for reporting purposes
 obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
 obj_term = OptimizationMethods.obj(progData, 
-    optData.iter_hist[optData.stop_iteration])
+    optData.iter_hist[optData.stop_iteration + 1])
+
 
 
 println(
@@ -39,7 +41,7 @@ println(
 
     Terminal Iteration: $(optData.stop_iteration)
     Terminal Objective: $obj_term
-    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration])
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration + 1])
 
     Objective Evaluations: $obj_evals
     Gradient Evaluations: $(progData.counters.neval_grad)

--- a/examples/prob-LS_solve-LipschitzApproxGD.jl
+++ b/examples/prob-LS_solve-LipschitzApproxGD.jl
@@ -1,7 +1,7 @@
 # Date: 10/04/2024
 # Author: Christian Varner
 # Purpose: Implement an example of running lipschitz_approximation_gd() on 
-# an instance of GaussianLeastSquares.
+# an instance of LeastSquares.
 
 using OptimizationMethods
 

--- a/examples/prob-LS_solve-bbGD.jl
+++ b/examples/prob-LS_solve-bbGD.jl
@@ -1,20 +1,19 @@
-# Date: 10/04/2024
-# Author: Christian Varner
-# Purpose: Implement an example of running lipschitz_approximation_gd() on 
-# an instance of GaussianLeastSquares.
-
 using OptimizationMethods
 
-progData = OptimizationMethods.GaussianLeastSquares(Float64);
-optData = OptimizationMethods.LipschitzApproxGD(
-    Float64, 
-    x0=randn(50), 
-    init_stepsize=0.0005, 
-    threshold=1e-10, 
-    max_iterations=100
+progData = OptimizationMethods.LeastSquares(Float64)
+optData = BarzilaiBorweinGD(
+    Float64,
+    x0 = randn(50),
+    init_stepsize = 1e-5,
+    long_stepsize = true,
+    threshold = 1e-10,
+    max_iterations = 100
 )
 
-x = OptimizationMethods.lipschitz_approximation_gd(optData, progData);
+x = barzilai_borwein_gd(
+    optData,
+    progData
+)
 
 # Compute objective and residual evals during optimization 
 obj_evals = progData.counters.neval_obj
@@ -24,7 +23,6 @@ res_evals = progData.counters.neval_residual
 obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
 obj_term = OptimizationMethods.obj(progData, 
     optData.iter_hist[optData.stop_iteration + 1])
-
 
 
 println(

--- a/examples/prob-LS_solve-fixedGD.jl
+++ b/examples/prob-LS_solve-fixedGD.jl
@@ -1,6 +1,6 @@
 using OptimizationMethods
 
-progData = OptimizationMethods.GaussianLeastSquares(Float64);
+progData = OptimizationMethods.LeastSquares(Float64);
 optData = OptimizationMethods.FixedStepGD(
     Float64, 
     x0=randn(50), 
@@ -18,7 +18,7 @@ res_evals = progData.counters.neval_residual
 # Compute objective values of different iterates for reporting purposes
 obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
 obj_term = OptimizationMethods.obj(progData, 
-    optData.iter_hist[optData.stop_iteration])
+    optData.iter_hist[optData.stop_iteration + 1])
 
 
 
@@ -36,7 +36,7 @@ println(
 
     Terminal Iteration: $(optData.stop_iteration)
     Terminal Objective: $obj_term
-    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration])
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration + 1])
 
     Objective Evaluations: $obj_evals
     Gradient Evaluations: $(progData.counters.neval_grad)

--- a/src/OptimizationMethods.jl
+++ b/src/OptimizationMethods.jl
@@ -24,7 +24,7 @@ Parametric type for pre-allocating data structures for an optimization problem.
 abstract type AbstractProblemAllocate{T} end
 
 ## Source Code
-include("problems/gaussian_least_squares.jl")
+include("problems/least_squares.jl")
 include("problems/logistic_regression.jl")
 
 

--- a/src/problems/least_squares.jl
+++ b/src/problems/least_squares.jl
@@ -3,8 +3,7 @@
 """
     LeastSquares{T,S} <: AbstractNLSModel{T,S}
 
-Implements a least squares problem where the coefficient matrix's and constant 
-    vector's entries are independent Gaussian random variables.
+Implements the data structure for defining a least squares problem.
 
 # Objective Function
 
@@ -152,7 +151,7 @@ Immutable structure for initializing and storing repeatedly used calculations
 
     PrecomputeGLS(prog::LeastSquares{T,S}) where {T,S}
 
-Computes `A'*A`, `A'*b`, `b'*b` given a Gaussian Least Squares program, `prog`. 
+Computes `A'*A`, `A'*b`, `b'*b` given a Least Squares program, `prog`. 
 """
 struct PrecomputeGLS{T} <: AbstractPrecompute{T}
     coef_t_coef::Matrix{T}
@@ -171,7 +170,7 @@ end
 """
     AllocateGLS{T} <: AbstractProblemAllocate{T}
 
-Immutable structure for preallocating important quantities for the Gaussian
+Immutable structure for preallocating important quantities for the
     Least Squares problem.
 
 # Fields 
@@ -189,7 +188,7 @@ Immutable structure for preallocating important quantities for the Gaussian
         preComp::precomputeGLS{T},
     ) where {T,S}
 
-Preallocates data structures for Gaussian Least Squares based on optimization
+Preallocates data structures for Least Squares based on optimization
     problem's data. The values of `r` and `grad` are set to zero of type `T`.
     `jac` and `hess` are set to `A` and `A'*A`. If `preComp` is supplied, then
     `hess` is set to `preComp.coef_t_coef`.
@@ -227,7 +226,7 @@ end
 """
     initialize(progData::LeastSquares{T,S}) where {T,S}
 
-Generates the precomputed and storage structs given a Gaussian Least Squares 
+Generates the precomputed and storage structs given a Least Squares 
     problem.
 """
 function initialize(progData::LeastSquares{T,S}) where {T,S}

--- a/src/problems/least_squares.jl
+++ b/src/problems/least_squares.jl
@@ -97,7 +97,7 @@ function LeastSquares(
     equal to number of entires in `x0`"
 
     meta = NLPModelMeta(
-        nvar = nvar,
+        nvar,
         name = "Least Squares",
         x0 = x0, 
     )

--- a/src/problems/least_squares.jl
+++ b/src/problems/least_squares.jl
@@ -136,7 +136,7 @@ function LeastSquares(
 end
 
 """
-    PrecomputeGLS{T} <: AbstractPrecompute{T}
+    PrecomputeLS{T} <: AbstractPrecompute{T}
 
 Immutable structure for initializing and storing repeatedly used calculations
     related to coefficient matrix `A` and constant vector `b`.
@@ -149,26 +149,26 @@ Immutable structure for initializing and storing repeatedly used calculations
 
 # Constructors
 
-    PrecomputeGLS(prog::LeastSquares{T,S}) where {T,S}
+    PrecomputeLS(prog::LeastSquares{T,S}) where {T,S}
 
 Computes `A'*A`, `A'*b`, `b'*b` given a Least Squares program, `prog`. 
 """
-struct PrecomputeGLS{T} <: AbstractPrecompute{T}
+struct PrecomputeLS{T} <: AbstractPrecompute{T}
     coef_t_coef::Matrix{T}
     coef_t_cons::Vector{T}
     cons_t_cons::T
 end
 
-function PrecomputeGLS(prog::LeastSquares{T,S}) where {T,S}
+function PrecomputeLS(prog::LeastSquares{T,S}) where {T,S}
     coef_t_coef = prog.coef'*prog.coef
     coef_t_cons = prog.coef'*prog.cons 
     cons_t_cons = prog.cons'*prog.cons
 
-    return PrecomputeGLS(coef_t_coef, coef_t_cons, cons_t_cons)
+    return PrecomputeLS(coef_t_coef, coef_t_cons, cons_t_cons)
 end
 
 """
-    AllocateGLS{T} <: AbstractProblemAllocate{T}
+    AllocateLS{T} <: AbstractProblemAllocate{T}
 
 Immutable structure for preallocating important quantities for the
     Least Squares problem.
@@ -182,10 +182,10 @@ Immutable structure for preallocating important quantities for the
 
 # Constructors
 
-    AllocateGLS(prog::LeastSquares{T,S}) where {T,S}
-    AllocateGLS(
+    AllocateLS(prog::LeastSquares{T,S}) where {T,S}
+    AllocateLS(
         prog::LeastSquares{T,S},
-        preComp::precomputeGLS{T},
+        preComp::precomputeLS{T},
     ) where {T,S}
 
 Preallocates data structures for Least Squares based on optimization
@@ -193,16 +193,16 @@ Preallocates data structures for Least Squares based on optimization
     `jac` and `hess` are set to `A` and `A'*A`. If `preComp` is supplied, then
     `hess` is set to `preComp.coef_t_coef`.
 """
-struct AllocateGLS{T} <: AbstractProblemAllocate{T}
+struct AllocateLS{T} <: AbstractProblemAllocate{T}
     res::Vector{T}
     jac::Matrix{T}
     grad::Vector{T}
     hess::Matrix{T}
 end
 
-function AllocateGLS(prog::LeastSquares{T,S}) where {T,S}
+function AllocateLS(prog::LeastSquares{T,S}) where {T,S}
 
-    return AllocateGLS(
+    return AllocateLS(
         zeros(T, prog.nls_meta.nequ),
         prog.coef,
         zeros(T, prog.nls_meta.nvar),
@@ -210,12 +210,12 @@ function AllocateGLS(prog::LeastSquares{T,S}) where {T,S}
     )
 end
 
-function AllocateGLS(
+function AllocateLS(
     prog::LeastSquares{T,S},
-    preComp::PrecomputeGLS{T}
+    preComp::PrecomputeLS{T}
 ) where {T,S}
 
-    return AllocateGLS(
+    return AllocateLS(
         zeros(T, prog.nls_meta.nequ),
         prog.coef,
         zeros(T, prog.nls_meta.nvar),
@@ -231,8 +231,8 @@ Generates the precomputed and storage structs given a Least Squares
 """
 function initialize(progData::LeastSquares{T,S}) where {T,S}
 
-    precompute = PrecomputeGLS(progData)
-    store = AllocateGLS(progData, precompute)
+    precompute = PrecomputeLS(progData)
+    store = AllocateLS(progData, precompute)
 
     return precompute, store
 end
@@ -336,7 +336,7 @@ end
 
 args_pre = [
     :(progData::LeastSquares{T,S}),
-    :(preComp::PrecomputeGLS{T}),
+    :(preComp::PrecomputeLS{T}),
     :(x::Vector{T})
 ]
 
@@ -423,8 +423,8 @@ end
 
 args_store = [
     :(progData::LeastSquares{T,S}),
-    :(preComp::PrecomputeGLS{T}),
-    :(store::AllocateGLS{T}),
+    :(preComp::PrecomputeLS{T}),
+    :(store::AllocateLS{T}),
     :(x::Vector{T})
 ]
 

--- a/src/problems/least_squares.jl
+++ b/src/problems/least_squares.jl
@@ -43,6 +43,21 @@ Constructs a least squares problems with `1000` equations and `50` unknowns,
 - `nequ::Int64=1000`, the number of equations in the system 
 - `nvar::Int64=50`, the number of parameters in the system 
 
+    LeastSquares(design::Matrix{T}, response::Vector{T}; 
+        x0 = ones(T, size(design, 2))) where {T}    
+
+Constructs a least squares problem using the `design` as the `coef` matrix
+and the `response` as the `cons` vector. 
+
+## Arguments
+
+- `design::Matrix{T}`, coefficient matrix for least squares.
+- `response::Vector{T}`, constant vector for least squares.
+
+## Optional Keyword Arguments
+
+- `x0::Vector{T}=ones(T, size(design, 2))`, default starting point for 
+    optimization algorithms.
 """
 mutable struct LeastSquares{T, S} <: AbstractNLSModel{T, S}
     meta::NLPModelMeta{T, S}
@@ -51,6 +66,7 @@ mutable struct LeastSquares{T, S} <: AbstractNLSModel{T, S}
     coef::Matrix{T}
     cons::Vector{T}
 
+    # inner constructor for to check invariant properties
     LeastSquares{T, S}(meta, nls_meta, counters, coef, cons) where {T, S} =
     begin
         @assert size(coef, 1) == length(cons) "Number of responses is not 
@@ -64,6 +80,7 @@ function LeastSquares(
     nvar::Int64 = 50
 ) where {T}
 
+    # Create structs from NLPModel
     meta = NLPModelMeta(
         nvar, 
         name = "Least Squares",
@@ -78,6 +95,7 @@ function LeastSquares(
         lin = collect(1:nequ),
     )
 
+    # return struct
     return LeastSquares{T, Vector{T}}(
         meta, 
         nls_meta, 
@@ -93,8 +111,6 @@ function LeastSquares(
 ) where {T}
 
     nequ, nvar = size(design)
-    @assert nvar == length(x0) "Number of columns in `design` is not
-    equal to number of entires in `x0`"
 
     meta = NLPModelMeta(
         nvar,
@@ -110,6 +126,7 @@ function LeastSquares(
         lin = collect(1:nequ),
     )
 
+    # return struct
     return LeastSquares{T, Vector{T}}(
         meta,
         nls_meta,

--- a/test/methods/gd_barzilai_borwein.jl
+++ b/test/methods/gd_barzilai_borwein.jl
@@ -74,7 +74,7 @@ using Test, OptimizationMethods, LinearAlgebra, Random
     # Test optimizer
     ##########################################
 
-    progData = OptimizationMethods.GaussianLeastSquares(Float64)
+    progData = OptimizationMethods.LeastSquares(Float64)
     x0 = progData.meta.x0
     ss = 1e-2
 

--- a/test/methods/gd_fixed.jl
+++ b/test/methods/gd_fixed.jl
@@ -122,7 +122,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # Test optimizer
     ##########################################
 
-    progData = OptimizationMethods.GaussianLeastSquares(Float64)
+    progData = OptimizationMethods.LeastSquares(Float64)
     x0 = randn(50)
     optData = OptimizationMethods.FixedStepGD(
         Float64, 

--- a/test/methods/gd_lipschitz_approximation.jl
+++ b/test/methods/gd_lipschitz_approximation.jl
@@ -72,7 +72,7 @@ using Test, OptimizationMethods, LinearAlgebra, Random
     # Test optimizer
     ##########################################
 
-    progData = OptimizationMethods.GaussianLeastSquares(Float64)
+    progData = OptimizationMethods.LeastSquares(Float64)
     x0 = progData.meta.x0
     ss = 1e-2
 

--- a/test/problems/least_squares.jl
+++ b/test/problems/least_squares.jl
@@ -1,33 +1,33 @@
 # Date: 09/24/2024
 # Author: Christian Varner
-# Purpose: Test the implementation of GaussianLeastSquares in
+# Purpose: Test the implementation of LeastSquares in
 # src/problems/gaussian_least_squares.jl
 
-module TestGaussianLeastSquares
+module TestLeastSquares
 
 using Test, OptimizationMethods, Random, LinearAlgebra
 
-@testset "Problem: Gaussian Least Squares" begin
+@testset "Problem: Least Squares" begin
 
     # Set the seed for reproducibility
     Random.seed!(1010)
 
     ####################################
-    # Test Struct: GaussianLeastSquares
+    # Test Struct: LeastSquares
     ####################################
 
     # test supertype
-    @test supertype(OptimizationMethods.GaussianLeastSquares) == OptimizationMethods.AbstractNLSModel
+    @test supertype(OptimizationMethods.LeastSquares) == OptimizationMethods.AbstractNLSModel
 
     # test fields
-    @test :meta in fieldnames(OptimizationMethods.GaussianLeastSquares)
-    @test :nls_meta in fieldnames(OptimizationMethods.GaussianLeastSquares)
-    @test :counters in fieldnames(OptimizationMethods.GaussianLeastSquares)
-    @test :coef in fieldnames(OptimizationMethods.GaussianLeastSquares) 
-    @test :cons in fieldnames(OptimizationMethods.GaussianLeastSquares) 
+    @test :meta in fieldnames(OptimizationMethods.LeastSquares)
+    @test :nls_meta in fieldnames(OptimizationMethods.LeastSquares)
+    @test :counters in fieldnames(OptimizationMethods.LeastSquares)
+    @test :coef in fieldnames(OptimizationMethods.LeastSquares) 
+    @test :cons in fieldnames(OptimizationMethods.LeastSquares) 
 
     # test constructor -- default values
-    nlp = OptimizationMethods.GaussianLeastSquares(Float64)
+    nlp = OptimizationMethods.LeastSquares(Float64)
 
     ## test arguments
     @test nlp.nls_meta.nequ == 1000
@@ -46,7 +46,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     @test size(nlp.cons)[1] == 1000
 
     # test constructor -- different type
-    nlp = OptimizationMethods.GaussianLeastSquares(Float16)
+    nlp = OptimizationMethods.LeastSquares(Float16)
 
     ## test arguments
     @test nlp.nls_meta.nequ == 1000
@@ -66,7 +66,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # test constructor -- non-default values
     nequ = rand(1:1000)[1]
     nvar = rand(1:1000)[1]
-    nlp = OptimizationMethods.GaussianLeastSquares(Float64; nequ = nequ, nvar = nvar)
+    nlp = OptimizationMethods.LeastSquares(Float64; nequ = nequ, nvar = nvar)
 
     ## test arguments
     @test nlp.nls_meta.nequ == nequ
@@ -95,7 +95,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     @test :coef_t_cons in fieldnames(OptimizationMethods.PrecomputeGLS)
 
     # test constructor -- default values
-    nlp = OptimizationMethods.GaussianLeastSquares(Float16)
+    nlp = OptimizationMethods.LeastSquares(Float16)
     precomp = OptimizationMethods.PrecomputeGLS(nlp)
 
     ## test field values -- correct definitions
@@ -111,7 +111,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # test constructor -- non-default values
     nequ = rand(1:1000)[1]
     nvar = rand(1:1000)[1]
-    nlp = OptimizationMethods.GaussianLeastSquares(Float64; nequ = nequ, nvar = nvar)
+    nlp = OptimizationMethods.LeastSquares(Float64; nequ = nequ, nvar = nvar)
     precomp = OptimizationMethods.PrecomputeGLS(nlp)
 
     ## test field values -- correct definitions
@@ -138,7 +138,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     @test :hess in fieldnames(OptimizationMethods.AllocateGLS)
 
     # test constructor -- no precomp -- default values
-    nlp = OptimizationMethods.GaussianLeastSquares(Float16) 
+    nlp = OptimizationMethods.LeastSquares(Float16) 
     store = OptimizationMethods.AllocateGLS(nlp)
 
     ## test field
@@ -156,7 +156,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # test constructor -- no precomp -- non-default values
     nequ = rand(1:1000)[1]
     nvar = rand(1:1000)[1] 
-    nlp = OptimizationMethods.GaussianLeastSquares(Float32; nequ = nequ, nvar = nvar) 
+    nlp = OptimizationMethods.LeastSquares(Float32; nequ = nequ, nvar = nvar) 
     store = OptimizationMethods.AllocateGLS(nlp)
 
     ## test field
@@ -172,7 +172,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     @test typeof(store.hess) == Matrix{Float32}
 
     # test constructor -- precomp -- default value
-    nlp = OptimizationMethods.GaussianLeastSquares(Float16) 
+    nlp = OptimizationMethods.LeastSquares(Float16) 
     precomp = OptimizationMethods.PrecomputeGLS(nlp)
     store = OptimizationMethods.AllocateGLS(nlp, precomp)
 
@@ -191,7 +191,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # test constructor -- precomp -- non-default value
     nequ = rand(1:1000)[1]
     nvar = rand(1:1000)[1] 
-    nlp = OptimizationMethods.GaussianLeastSquares(Float64; nequ = nequ, nvar = nvar) 
+    nlp = OptimizationMethods.LeastSquares(Float64; nequ = nequ, nvar = nvar) 
     precomp = OptimizationMethods.PrecomputeGLS(nlp)
     store = OptimizationMethods.AllocateGLS(nlp)
 
@@ -212,7 +212,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     ######################################
 
     # testing with default values
-    nlp = OptimizationMethods.GaussianLeastSquares(Float16) 
+    nlp = OptimizationMethods.LeastSquares(Float16) 
     precomp = OptimizationMethods.PrecomputeGLS(nlp)
     store = OptimizationMethods.AllocateGLS(nlp) 
 
@@ -243,7 +243,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # Test Functionality: Operations - not in-place and not using precomputed values
     ################################################################################
 
-    nlp = OptimizationMethods.GaussianLeastSquares(Float32) 
+    nlp = OptimizationMethods.LeastSquares(Float32) 
     x0 = randn(Float32, 50)
 
     # residual
@@ -293,7 +293,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # Test Functionality: Operations - not in-place and using precomputed values
     ################################################################################
 
-    nlp = OptimizationMethods.GaussianLeastSquares(Float16)
+    nlp = OptimizationMethods.LeastSquares(Float16)
     precomp, store = OptimizationMethods.initialize(nlp)
     x0 = randn(Float16, 50)
 
@@ -347,7 +347,7 @@ using Test, OptimizationMethods, Random, LinearAlgebra
     # Test Functionality: Operations - in-place and using precomputed values
     ################################################################################
 
-    nlp = OptimizationMethods.GaussianLeastSquares(Float32)
+    nlp = OptimizationMethods.LeastSquares(Float32)
     precomp, store = OptimizationMethods.initialize(nlp)
     x0 = randn(Float32, 50)
 

--- a/test/problems/least_squares.jl
+++ b/test/problems/least_squares.jl
@@ -1,7 +1,7 @@
 # Date: 09/24/2024
 # Author: Christian Varner
 # Purpose: Test the implementation of LeastSquares in
-# src/problems/gaussian_least_squares.jl
+# src/problems/least_squares.jl
 
 module TestLeastSquares
 

--- a/test/test.txt
+++ b/test/test.txt
@@ -1,4 +1,4 @@
-problems/gaussian_least_squares.jl
+problems/least_squares.jl
 problems/logistic_regression.jl
 methods/gd_fixed.jl
 methods/gd_barzilai_borwein.jl


### PR DESCRIPTION
# Change Summary

As outlined in issue #9, this branch includes the following changes:

1. Renaming `GaussianLeastSquares` to `LeastSquares`
2. Updates to files to reflect renaming changes (this includes in `OptimizationMethods.jl`, `examples/`, and test cases)
3. Adding a new constructor for the `struct` that allows user defined `coef` and `cons` arguments
4. Updates to the test file for this new constructor

We also address indexing problems in the previous files in `examples`. Specifically, changing `stop_iteration` to `stop_iteration + 1`.

Closes #9 