### PR TITLE
Bug Fixes: Test cases for the variance functions and logistic regression

### DIFF
--- a/test/problems/logistic_regression.jl
+++ b/test/problems/logistic_regression.jl
@@ -224,41 +224,43 @@ using Test, ForwardDiff, OptimizationMethods, Random, LinearAlgebra, NLPModels
 
     # test problem 2
     
-    progData = OptimizationMethods.LogisticRegression(Float64)
-    nobs, nvar = size(progData.design)
-    A = progData.design
-    b = progData.response
-    logistic = OptimizationMethods.logistic
+    let
+        progData = OptimizationMethods.LogisticRegression(Float64)
+        nobs, nvar = size(progData.design)
+        A = progData.design
+        b = progData.response
+        logistic = OptimizationMethods.logistic
 
-    function F(x::Vector)
-        probs = logistic.(A * x)
-        return - b' * log.(probs) - (1 .- b)' * log.(1 .- probs)
+        function F(x::Vector)
+            probs = logistic.(A * x)
+            return - b' * log.(probs) - (1 .- b)' * log.(1 .- probs)
+        end
+
+        x = randn(nvar)
+
+        ## test objective
+        o = obj(progData, x)
+        o_true = F(x)
+        @test isapprox(o - o_true, 0, atol = 1e-10)
+
+        ## test gradient
+        g = grad(progData, x)
+        g_autodiff = ForwardDiff.gradient(F, x) 
+        @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10)
+
+        ## test objgrad
+        output = objgrad(progData, x)
+        o, g = output[1], output[2]
+    
+        g_autodiff = ForwardDiff.gradient(F, x)
+        @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10) 
+        @test isapprox(norm(o - F(x)), 0, atol = 1e-10)
+
+        ## test hess
+        h = OptimizationMethods.hess(progData, x)
+        h_autodiff = ForwardDiff.hessian(F, x)
+        @test isapprox(norm(h - h_autodiff), 0; atol = 1e-10)
     end
-
-    x = randn(nvar)
-
-    ## test objective
-    o = obj(progData, x)
-    o_true = F(x)
-    @test isapprox(o - o_true, 0, atol = 1e-10)
-
-    ## test gradient
-    g = grad(progData, x)
-    g_autodiff = ForwardDiff.gradient(F, x) 
-    @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10)
-
-    ## test objgrad
-    output = objgrad(progData, x)
-    o, g = output[1], output[2]
-   
-    g_autodiff = ForwardDiff.gradient(F, x)
-    @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10) 
-    @test isapprox(norm(o - F(x)), 0, atol = 1e-10)
-
-    ## test hess
-    h = OptimizationMethods.hess(progData, x)
-    h_autodiff = ForwardDiff.hessian(F, x)
-    @test isapprox(norm(h - h_autodiff), 0; atol = 1e-10)
 
     ####################################
     # Test functionality - group 2
@@ -311,42 +313,44 @@ using Test, ForwardDiff, OptimizationMethods, Random, LinearAlgebra, NLPModels
     
     # test problem 2
 
-    progData = OptimizationMethods.LogisticRegression(Float64)
-    precomp, store = OptimizationMethods.initialize(progData)
-    nobs, nvar = size(progData.design)
-    A = progData.design
-    b = progData.response
-    logistic = OptimizationMethods.logistic
+    let
+        progData = OptimizationMethods.LogisticRegression(Float64)
+        precomp, store = OptimizationMethods.initialize(progData)
+        nobs, nvar = size(progData.design)
+        A = progData.design
+        b = progData.response
+        logistic = OptimizationMethods.logistic
 
-    function F(x::Vector)
-        probs = logistic.(A * x)
-        return - b' * log.(probs) - (1 .- b)' * log.(1 .- probs)
+        function F(x::Vector)
+            probs = logistic.(A * x)
+            return - b' * log.(probs) - (1 .- b)' * log.(1 .- probs)
+        end
+
+        x = randn(nvar)
+
+        ## test objective
+        o = obj(progData, precomp, x)
+        o_true = F(x)
+        @test isapprox(o - o_true, 0, atol = 1e-10)
+
+        ## test gradient
+        g = grad(progData, precomp, x)
+        g_autodiff = ForwardDiff.gradient(F, x) 
+        @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10)
+
+        ## test objgrad
+        output = objgrad(progData, precomp, x)
+        o, g = output[1], output[2]
+    
+        g_autodiff = ForwardDiff.gradient(F, x)
+        @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10) 
+        @test isapprox(norm(o - F(x)), 0, atol = 1e-10)
+
+        ## test hess
+        h = OptimizationMethods.hess(progData, precomp, x)
+        h_autodiff = ForwardDiff.hessian(F, x)
+        @test isapprox(norm(h - h_autodiff), 0; atol = 1e-10)
     end
-
-    x = randn(nvar)
-
-    ## test objective
-    o = obj(progData, precomp, x)
-    o_true = F(x)
-    @test isapprox(o - o_true, 0, atol = 1e-10)
-
-    ## test gradient
-    g = grad(progData, precomp, x)
-    g_autodiff = ForwardDiff.gradient(F, x) 
-    @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10)
-
-    ## test objgrad
-    output = objgrad(progData, precomp, x)
-    o, g = output[1], output[2]
-   
-    g_autodiff = ForwardDiff.gradient(F, x)
-    @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10) 
-    @test isapprox(norm(o - F(x)), 0, atol = 1e-10)
-
-    ## test hess
-    h = OptimizationMethods.hess(progData, precomp, x)
-    h_autodiff = ForwardDiff.hessian(F, x)
-    @test isapprox(norm(h - h_autodiff), 0; atol = 1e-10)
     
     ####################################
     # Test functionality - group 3
@@ -402,44 +406,46 @@ using Test, ForwardDiff, OptimizationMethods, Random, LinearAlgebra, NLPModels
     
     # Test problem 2
 
-    progData = OptimizationMethods.LogisticRegression(Float64)
-    precomp, store = OptimizationMethods.initialize(progData)
-    nobs, nvar = size(progData.design)
-    A = progData.design
-    b = progData.response
-    logistic = OptimizationMethods.logistic
+    let
+        progData = OptimizationMethods.LogisticRegression(Float64)
+        precomp, store = OptimizationMethods.initialize(progData)
+        nobs, nvar = size(progData.design)
+        A = progData.design
+        b = progData.response
+        logistic = OptimizationMethods.logistic
 
-    function F(x::Vector)
-        probs = logistic.(A * x)
-        return - b' * log.(probs) - (1 .- b)' * log.(1 .- probs)
+        function F(x::Vector)
+            probs = logistic.(A * x)
+            return - b' * log.(probs) - (1 .- b)' * log.(1 .- probs)
+        end
+
+        x = randn(nvar)
+
+        ## test objective
+        o = obj(progData, precomp, store, x)
+        o_true = F(x)
+        @test isapprox(o - o_true, 0, atol = 1e-10)
+
+        ## test gradient
+        grad!(progData, precomp, store, x)
+        g = store.grad
+        g_autodiff = ForwardDiff.gradient(F, x) 
+        @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10)
+
+        ## test objgrad
+        output = objgrad!(progData, precomp, store, x)
+        o, g = output, store.grad
+    
+        g_autodiff = ForwardDiff.gradient(F, x)
+        @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10) 
+        @test isapprox(norm(o - F(x)), 0, atol = 1e-10)
+
+        ## test hess
+        OptimizationMethods.hess!(progData, precomp, store, x)
+        h = store.hess
+        h_autodiff = ForwardDiff.hessian(F, x)
+        @test isapprox(norm(h - h_autodiff), 0; atol = 1e-10)
     end
-
-    x = randn(nvar)
-
-    ## test objective
-    o = obj(progData, precomp, store, x)
-    o_true = F(x)
-    @test isapprox(o - o_true, 0, atol = 1e-10)
-
-    ## test gradient
-    grad!(progData, precomp, store, x)
-    g = store.grad
-    g_autodiff = ForwardDiff.gradient(F, x) 
-    @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10)
-
-    ## test objgrad
-    output = objgrad!(progData, precomp, store, x)
-    o, g = output, store.grad
-   
-    g_autodiff = ForwardDiff.gradient(F, x)
-    @test isapprox(norm(g - g_autodiff), 0, atol = 1e-10) 
-    @test isapprox(norm(o - F(x)), 0, atol = 1e-10)
-
-    ## test hess
-    OptimizationMethods.hess!(progData, precomp, store, x)
-    h = store.hess
-    h_autodiff = ForwardDiff.hessian(F, x)
-    @test isapprox(norm(h - h_autodiff), 0; atol = 1e-10)
 end
 
 end # end module

--- a/test/problems/regression_helpers/variance_functions.jl
+++ b/test/problems/regression_helpers/variance_functions.jl
@@ -2,7 +2,7 @@
 # Author: Christian Varner
 # Purpose: Test variance functions
 
-module ProceduralLinkFunctions
+module ProceduralVarianceFunctions
 
 using Test, OptimizationMethods, Random
 


### PR DESCRIPTION
# Summary

1. Changed the name for the module for testing the variance functions, as it had the same name as the module for testing the link function causing an error. 
2. There was a function that was being redefined multiple times in the logistic regression file, so the test cases requiring this function have been moved into `let` blocks.

Closes #40
Closes #39 