### PR TITLE
Modified Newton Globalized Through Watchdog

### DIFF
--- a/docs/src/api_methods.md
+++ b/docs/src/api_methods.md
@@ -8,6 +8,7 @@ Pages=["api_methods.md"]
 
 ```@docs
 barzilai_borwein_gd
+
 BarzilaiBorweinGD
 ```
 
@@ -183,11 +184,13 @@ OptimizationMethods.non_sequential_armijo_condition
 # Second Order Helper Functions
 
 ## Hessian Modification
+
 ```@docs
 OptimizationMethods.add_identity_until_pd!
 ```
 
 ## Quasi-Newton Updates
+
 ```@docs
 OptimizationMethods.update_bfgs!
 ```

--- a/docs/src/api_methods.md
+++ b/docs/src/api_methods.md
@@ -61,6 +61,15 @@ OptimizationMethods.inverse_log2k_step_size
 OptimizationMethods.stepdown_100_step_size
 ```
 
+# Watchdog Technique with Nonmonotone Line Search
+
+## Second Order Methods
+```@docs
+nonsequential_armijo_mnewton_fixed_gd
+
+NonsequentialArmijoFixedMNewtonGD
+```
+
 # Non-sequential Armijo Line Search with Event Triggered Objective Evaluations
 
 ## First Order Methods

--- a/examples/prob-LR_solve-WatchdogMNewton.jl
+++ b/examples/prob-LR_solve-WatchdogMNewton.jl
@@ -1,0 +1,111 @@
+using OptimizationMethods
+
+progData = OptimizationMethods.LogisticRegression(Float64)
+
+x0 = randn(50)
+optData = OptimizationMethods.WatchdogFixedMNewtonGD(
+    Float64;
+    x0 = x0,
+    β = 1e-3,
+    λ = 0.0,
+    hessian_modification_max_iteration = 10,
+    α = 1.0,
+    δ = 0.5,
+    ρ = 1e-4,
+    line_search_max_iterations = 100,
+    η = 1e-6,
+    inner_loop_max_iterations = 50,
+    window_size = 1,
+    threshold = 1e-10,
+    max_iterations = 100
+)
+
+x = OptimizationMethods.watchdog_fixed_mnewton_gd(optData, progData)
+
+# Compute objective and residual evals during optimization 
+obj_evals = progData.counters.neval_obj
+
+# Compute objective values of different iterates for reporting purposes
+obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
+obj_term = OptimizationMethods.obj(progData, 
+    optData.iter_hist[optData.stop_iteration + 1])
+
+
+println(
+"""
+    Problem: $(progData.meta.name)
+    Nonmonotone: $(length(optData.objective_hist) != 1)
+    Solver: $(optData.name)
+    Parameter Dimension: $(progData.meta.nvar)
+    
+    Max Iterations Allowed: $(optData.max_iterations)
+    Gradient Stopping Threshold: $(optData.threshold)
+
+    Initial Objective: $obj_init
+    Initial Grad Norm: $(optData.grad_val_hist[1])
+
+    Terminal Iteration: $(optData.stop_iteration)
+    Terminal Objective: $obj_term
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration + 1])
+
+    Objective Evaluations: $obj_evals
+    Gradient Evaluations: $(progData.counters.neval_grad)
+    Hessian Evaluations: $(progData.counters.neval_hess)
+"""
+)
+
+# reset for different parameters
+progData.counters.neval_obj = 0
+progData.counters.neval_grad = 0
+progData.counters.neval_hess = 0
+
+optData = OptimizationMethods.WatchdogFixedMNewtonGD(
+    Float64;
+    x0 = x0,
+    β = 1e-3,
+    λ = 0.0,
+    hessian_modification_max_iteration = 10,
+    α = 1.0,
+    δ = 0.5,
+    ρ = 1e-4,
+    line_search_max_iterations = 100,
+    η = 1e-6,
+    inner_loop_max_iterations = 50,
+    window_size = 5,
+    threshold = 1e-10,
+    max_iterations = 100
+)
+
+x = OptimizationMethods.watchdog_fixed_mnewton_gd(optData, progData)
+
+# Compute objective and residual evals during optimization 
+obj_evals = progData.counters.neval_obj
+
+# Compute objective values of different iterates for reporting purposes
+obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
+obj_term = OptimizationMethods.obj(progData, 
+    optData.iter_hist[optData.stop_iteration + 1])
+
+
+println(
+"""
+    Problem: $(progData.meta.name)
+    Nonmonotone: $(length(optData.objective_hist) != 1)
+    Solver: $(optData.name)
+    Parameter Dimension: $(progData.meta.nvar)
+    
+    Max Iterations Allowed: $(optData.max_iterations)
+    Gradient Stopping Threshold: $(optData.threshold)
+
+    Initial Objective: $obj_init
+    Initial Grad Norm: $(optData.grad_val_hist[1])
+
+    Terminal Iteration: $(optData.stop_iteration)
+    Terminal Objective: $obj_term
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration + 1])
+
+    Objective Evaluations: $obj_evals
+    Gradient Evaluations: $(progData.counters.neval_grad)
+    Hessian Evaluations: $(progData.counters.neval_hess)
+"""
+)

--- a/examples/prob-PR_solve-WatchdogMNewton.jl
+++ b/examples/prob-PR_solve-WatchdogMNewton.jl
@@ -1,0 +1,111 @@
+using OptimizationMethods
+
+progData = OptimizationMethods.PoissonRegression(Float64)
+
+x0 = randn(50)
+optData = OptimizationMethods.WatchdogFixedMNewtonGD(
+    Float64;
+    x0 = x0,
+    β = 1e-3,
+    λ = 0.0,
+    hessian_modification_max_iteration = 10,
+    α = 1.0,
+    δ = 0.5,
+    ρ = 1e-4,
+    line_search_max_iterations = 100,
+    η = 1e-6,
+    inner_loop_max_iterations = 50,
+    window_size = 1,
+    threshold = 1e-10,
+    max_iterations = 100
+)
+
+x = OptimizationMethods.watchdog_fixed_mnewton_gd(optData, progData)
+
+# Compute objective and residual evals during optimization 
+obj_evals = progData.counters.neval_obj
+
+# Compute objective values of different iterates for reporting purposes
+obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
+obj_term = OptimizationMethods.obj(progData, 
+    optData.iter_hist[optData.stop_iteration + 1])
+
+
+println(
+"""
+    Problem: $(progData.meta.name)
+    Nonmonotone: $(length(optData.objective_hist) != 1)
+    Solver: $(optData.name)
+    Parameter Dimension: $(progData.meta.nvar)
+    
+    Max Iterations Allowed: $(optData.max_iterations)
+    Gradient Stopping Threshold: $(optData.threshold)
+
+    Initial Objective: $obj_init
+    Initial Grad Norm: $(optData.grad_val_hist[1])
+
+    Terminal Iteration: $(optData.stop_iteration)
+    Terminal Objective: $obj_term
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration + 1])
+
+    Objective Evaluations: $obj_evals
+    Gradient Evaluations: $(progData.counters.neval_grad)
+    Hessian Evaluations: $(progData.counters.neval_hess)
+"""
+)
+
+# reset for different parameters
+progData.counters.neval_obj = 0
+progData.counters.neval_grad = 0
+progData.counters.neval_hess = 0
+
+optData = OptimizationMethods.WatchdogFixedMNewtonGD(
+    Float64;
+    x0 = x0,
+    β = 1e-3,
+    λ = 0.0,
+    hessian_modification_max_iteration = 10,
+    α = 1.0,
+    δ = 0.5,
+    ρ = 1e-4,
+    line_search_max_iterations = 100,
+    η = 1e-6,
+    inner_loop_max_iterations = 50,
+    window_size = 1,
+    threshold = 1e-10,
+    max_iterations = 100
+)
+
+x = OptimizationMethods.watchdog_fixed_mnewton_gd(optData, progData)
+
+# Compute objective and residual evals during optimization 
+obj_evals = progData.counters.neval_obj
+
+# Compute objective values of different iterates for reporting purposes
+obj_init = OptimizationMethods.obj(progData, optData.iter_hist[1])
+obj_term = OptimizationMethods.obj(progData, 
+    optData.iter_hist[optData.stop_iteration + 1])
+
+
+println(
+"""
+    Problem: $(progData.meta.name)
+    Nonmonotone: $(length(optData.objective_hist) != 1)
+    Solver: $(optData.name)
+    Parameter Dimension: $(progData.meta.nvar)
+    
+    Max Iterations Allowed: $(optData.max_iterations)
+    Gradient Stopping Threshold: $(optData.threshold)
+
+    Initial Objective: $obj_init
+    Initial Grad Norm: $(optData.grad_val_hist[1])
+
+    Terminal Iteration: $(optData.stop_iteration)
+    Terminal Objective: $obj_term
+    Terminal Grad Norm: $(optData.grad_val_hist[optData.stop_iteration + 1])
+
+    Objective Evaluations: $obj_evals
+    Gradient Evaluations: $(progData.counters.neval_grad)
+    Hessian Evaluations: $(progData.counters.neval_hess)
+"""
+)

--- a/src/OptimizationMethods.jl
+++ b/src/OptimizationMethods.jl
@@ -88,6 +88,7 @@ export WeightedNormDampingGD, weighted_norm_damping_gd
 export NonsequentialArmijoAdaptiveGD, nonsequential_armijo_adaptive_gd
 export NonsequentialArmijoFixedGD, nonsequential_armijo_fixed_gd
 export NonsequentialArmijoFixedMNewtonGD, nonsequential_armijo_mnewton_fixed_gd
+export WatchdogFixedMNewtonGD, watchdog_fixed_mnewton_gd
 
 ## Helper functions for optimization methods
 include("methods/stepsize_helpers/diminishing_stepsizes.jl")
@@ -107,5 +108,6 @@ include("methods/gd_weighted_norm_damping.jl")
 include("methods/gd_non_sequential_armijo_adaptive.jl")
 include("methods/gd_non_sequential_armijo_fixed.jl")
 include("methods/gd_non_sequential_armijo_fixed_mnewton.jl")
+include("methods/gd_watchdog_fixed_mnewton.jl")
 
 end

--- a/src/OptimizationMethods.jl
+++ b/src/OptimizationMethods.jl
@@ -102,7 +102,6 @@ export FixedDampedBFGSNLSMaxValGD, fixed_damped_bfgs_nls_maxval_gd
 include("methods/stepsize_helpers/diminishing_stepsizes.jl")
 include("methods/line_search_helpers/backtracking.jl")
 include("methods/line_search_helpers/non_sequential_armijo.jl")
-include("methods/line_search_helpers/backtracking.jl")
 
 ### Helper functions for second order optimization methods
 include("methods/second_order_helpers/modified_newton.jl")

--- a/src/OptimizationMethods.jl
+++ b/src/OptimizationMethods.jl
@@ -93,6 +93,7 @@ export WatchdogFixedMNewtonGD, watchdog_fixed_mnewton_gd
 ## Helper functions for optimization methods
 include("methods/stepsize_helpers/diminishing_stepsizes.jl")
 include("methods/line_search_helpers/non_sequential_armijo.jl")
+include("methods/line_search_helpers/backtracking.jl")
 
 ### Helper functions for second order optimization methods
 include("methods/second_order_helpers/modified_newton.jl")

--- a/src/methods/gd_watchdog_fixed_mnewton.jl
+++ b/src/methods/gd_watchdog_fixed_mnewton.jl
@@ -1,0 +1,248 @@
+# Date: 2025/05/06
+# Author: Christian Varner
+# Purpose: Implementation of the fixed step size modified newton
+# method globalized through the watchdog technique
+
+"""
+"""
+mutable struct WatchdogFixedMNewtonGD{T} <: AbstractOptimizerData{T}
+    name::String
+    F_θk::T
+    ∇F_θk::Vector{T}
+    ∇∇F_θk::Matrix{T}
+    norm_∇F_ψ::T
+    # modified newton helpers
+    β::T
+    λ::T
+    hessian_modification_max_iteration::Int64
+    d0k::Vector{T}
+    # line search parameters
+    α::T
+    δ::T
+    ρ::T
+    line_search_max_iterations::Int64
+    max_distance_squared::T
+    # watchdog stopping parameters
+    η::T
+    inner_loop_max_iterations::Int64
+    # nonmonotone line search reference values
+    objective_hist::CircularVector{T, Vector{T}}
+    reference_value::T
+    reference_value_index::Int64
+    # default parameters
+    threshold::T
+    max_iterations::Int64
+    iter_hist::Vector{Vector{T}}
+    grad_val_hist::Vector{T}
+    stop_iteration::Int64
+end
+function WatchdogFixedMNewtonGD(::Type{T};
+    x0::Vector{T},
+    β::T,
+    λ::T,
+    hessian_modification_max_iteration::Int64,
+    α::T,
+    δ::T,
+    ρ::T,
+    line_search_max_iterations::Int64,
+    η,
+    inner_loop_max_iterations::Int64,
+    window_size::Int64,
+    threshold::T,
+    max_iterations::Int64
+) where {T}
+    
+    name::String = "Gradient Descent with fixed step size and modified"*
+    " Newton directions, globalized through Watchdog."
+
+    # initialize buffer for history keeping
+    d = length(x0)
+    iter_hist::Vector{Vector{T}} = Vector{Vector{T}}([
+        Vector{T}(undef, d) for i in 1:(max_iterations + 1)
+    ])
+    iter_hist[1] = x0
+
+    grad_val_hist::Vector{T} = Vector{T}(undef, max_iterations + 1)
+    stop_iteration::Int64 = -1 # dummy value
+
+    return WatchdogFixedMNewtonGD{T}(
+        name,
+        T(0),
+        zeros(T, d),
+        zeros(T, d, d),
+        T(0),
+        β,
+        λ,
+        hessian_modification_max_iteration,
+        zeros(T, d),
+        α,
+        δ,
+        ρ,
+        line_search_max_iterations,
+        T(0),
+        η,
+        inner_loop_max_iterations,
+        CircularVector(zeros(T, window_size)),
+        T(0),
+        -1,
+        threshold,
+        max_iterations,
+        iter_hist,
+        grad_val_hist,
+        stop_iteration
+    )
+end
+
+"""
+"""
+function inner_loop!(
+    ψjk::S,
+    θk::S,
+    optData::WatchdogFixedMNewtonGD{T}, 
+    progData::P1 where P1 <: AbstractNLPModel{T, S}, 
+    precomp::P2 where P2 <: AbstractPrecompute{T}, 
+    store::P3 where P3 <: AbstractProblemAllocate{T}, 
+    k::Int64; 
+    max_iterations = 100) where {T}
+
+    # initialization for inner loop
+    j::Int64 = 0
+    dist::T = T(0)
+    optData.max_distance_squared = T(0)
+    optData.norm_∇F_ψ = optData.grad_val_hist[k]
+
+    # stopping conditions
+    while j < max_iterations
+
+        # Increment the inner loop counter
+        j += 1
+
+        # hessian modification
+        res = add_identity_until_pd!(store.hess;
+            λ = optData.λ,
+            β = optData.β,
+            max_iterations = optData.hessian_modification_max_iteration)
+
+        # if modification failed take negative gradient step; otherwise
+        # take a modified newton step
+        if !res[2]
+            ψjk .-= optData.α .* store.grad
+        else
+            optData.λ = res[1] / 2
+            lower_triangle_solve!(store.grad, store.hess')
+            upper_triangle_solve!(store.grad, store.hess)
+            ψjk .-= optData.α .* store.grad
+        end
+
+        # save the first step in case we need to backtrack
+        if j == 1
+            optData.d0k .= store.grad
+        end
+
+        # update the maximum distance
+        dist = norm(ψjk - θk)
+        optData.max_distance_squared = max(dist^2, optData.max_distance_squared)
+
+        # store values for next iteration
+        OptimizationMethods.grad!(progData, precomp, store, ψjk)
+        OptimizationMethods.hess!(progData, precomp, store, ψjk)
+        optData.norm_∇F_ψ = norm(store.grad)
+
+        # check other stopping condition
+        if optData.norm_∇F_ψ <= optData.η * (1 + abs(optData.F_θk))
+            if OptimizationMethods.obj!(progData, precomp, store, ψjk) <= optData.reference_value
+                return j
+            end
+        end
+
+    end # end while loop
+
+    return j
+
+end
+
+"""
+"""
+function watchdog_fixed_mnewton_gd(
+    optData::WatchdogFixedMNewtonGD{T},
+    progData::P where P <: AbstractNLPModel{T, S}
+) where {T, S}
+
+    # initialize the problem data nd save initial values
+    precomp, store = OptimizationMethods.initialize(progData)
+    F(θ) = OptimizationMethods.obj(progData, precomp, store, θ)
+    
+    # initial iteration
+    iter = 0
+    x = copy(optData.iter_hist[1])
+    OptimizationMethods.hess!(progData, precomp, store, x)
+    OptimizationMethods.grad!(progData, precomp, store, x)
+    optData.grad_val_hist[1] = norm(store.grad)
+
+    # Initialize the objective history
+    M = length(optData.objective_hist)
+    optData.objective_hist[1] = F(optData.iter_hist[1]) 
+    optData.reference_value, optData.reference_value_index = 
+        optData.objective_hist[1], 1
+
+    while (iter < optData.max_iterations) && 
+        (optData.grad_val_hist[iter + 1] > optData.threshold)
+
+        # Increment iteration counter
+        iter += 1
+
+        # inner loop
+        optData.F_θk = optData.objective_hist[iter]
+        optData.∇F_θk .= store.grad
+        optData.∇∇F_θk .= store.hess
+        inner_loop!(x, optData.iter_hist[iter], optData, progData,
+            precomp, store, iter; 
+            max_iterations = optData.inner_loop_max_iterations)
+        Fx = F(x)
+
+        # if watchdog not successful, try to backtrack
+        if Fx > optData.reference_value - optData.ρ * optData.max_distance_squared
+
+            # revert to previous iterate
+            x .= optData.iter_hist[iter]
+
+            # backtrack on the previous iterate
+            backtrack_success = OptimizationMethods.backtracking!(
+                x,
+                optData.iter_hist[iter],
+                F,
+                optData.∇F_θk,
+                optData.d0k,
+                optData.reference_value,
+                optData.α,
+                optData.δ,
+                optData.ρ;
+                max_iteration = optData.line_search_max_iterations)
+
+            # if backtrack not successful terminate algorithm
+            if !backtrack_success
+                optData.stop_iteration = (iter - 1)
+                return optData.iter_hist[iter]
+            end
+
+            Fx = F(x)
+        end
+
+        # update the objective_hist
+        optData.objective_hist[iter + 1] = Fx
+        if (iter % M) + 1 == optData.reference_value_index
+            optData.reference_value, optData.reference_value_index =
+                findmax(optData.objective_hist)
+        end
+
+        # update iter and grad value history
+        OptimizationMethods.grad!(progData, precomp, store, ψjk)
+        OptimizationMethods.hess!(progData, precomp, store, ψjk)
+        optData.grad_val_hist = norm(store.grad)
+        optData.iter_hist[iter + 1] .= x
+    end
+
+    optData.stop_iteration = iter
+
+    return x
+end

--- a/src/methods/gd_watchdog_fixed_mnewton.jl
+++ b/src/methods/gd_watchdog_fixed_mnewton.jl
@@ -24,8 +24,7 @@ Mutable structure that parameterizes gradient descent with fixed step sizes
 - `hessian_modification_max_iteration::Int64`, max iteration for the hessian
     modification routine.
 - `d0k::Vector{T}`, buffer array for the first step of the inner loop.
-    Saved in case the inner loop fails and backtracking using this step
-    is required.
+    Saved in case the inner loop fails for the backtracking routine.
 - `α::T`, fixed step size used in the inner loop.
 - `δ::T`, step size reduction parameter used in the line search routine. 
 - `ρ::T`, parameter used in backtracking and the watchdog condition. Larger
@@ -208,7 +207,8 @@ at least one of the conditions are satisfied:
 The step direction ``d_i^k`` is one of the following. Let ``\\ddot F(\\psi_i^k)``
 be the hessian matrix of ``F`` at ``\\psi_i^k`` for ``i + 1 \\in \\mathbb{N}``
 and ``k + 1 \\in \\mathbb{N}``. Then, if 
-[OptimizationMethods.add_identity_until_pd!](@ref) successful modifies
+[the hessian modification routine](@ref OptimizationMethods.add_identity_until_pd!) 
+successful modifies
 ``\\ddot F(\\psi_i^k)`` to be positive definite, returning ``H_i^k``, then
 
 ```math
@@ -311,6 +311,9 @@ end
     watchdog_fixed_mnewton_gd(optData::WatchdogFixedMNewtonGD{T},
         progData::P where P <: AbstractNLPModel{T, S}) where {T, S}
 
+Fixed step size modified Newton method globlized through the watchdog technique, 
+parameterized by `optData`, applied to an optimization problem specified by `progData`. 
+
 # Reference(s)
 
 [Grippo L. and Sciandrone M. "Nonmonotone Globalization Techniques
@@ -380,7 +383,7 @@ function watchdog_fixed_mnewton_gd(
     progData::P where P <: AbstractNLPModel{T, S}
 ) where {T, S}
 
-    # initialize the problem data nd save initial values
+    # initialize the problem data and save initial values
     precomp, store = OptimizationMethods.initialize(progData)
     F(θ) = OptimizationMethods.obj(progData, precomp, store, θ)
     

--- a/src/methods/gd_watchdog_fixed_mnewton.jl
+++ b/src/methods/gd_watchdog_fixed_mnewton.jl
@@ -435,7 +435,13 @@ function watchdog_fixed_mnewton_gd(
                 return optData.iter_hist[iter]
             end
 
+            OptimizationMethods.grad!(progData, precomp, store, x)
+            optData.grad_val_hist[iter + 1] = norm(store.grad)
+
             Fx = F(x)
+        else
+            optData.grad_val_hist[iter + 1] = 
+                optData.norm_∇F_ψ
         end
 
         # update the objective_hist
@@ -446,9 +452,7 @@ function watchdog_fixed_mnewton_gd(
         end
 
         # update iter and grad value history
-        OptimizationMethods.grad!(progData, precomp, store, ψjk)
-        OptimizationMethods.hess!(progData, precomp, store, ψjk)
-        optData.grad_val_hist = norm(store.grad)
+        OptimizationMethods.hess!(progData, precomp, store, x)
         optData.iter_hist[iter + 1] .= x
     end
 

--- a/src/methods/gd_watchdog_fixed_mnewton.jl
+++ b/src/methods/gd_watchdog_fixed_mnewton.jl
@@ -248,7 +248,7 @@ function inner_loop!(
     precomp::P2 where P2 <: AbstractPrecompute{T}, 
     store::P3 where P3 <: AbstractProblemAllocate{T}, 
     k::Int64; 
-    max_iterations = 100) where {T}
+    max_iterations = 100) where {T, S}
 
     # initialization for inner loop
     j::Int64 = 0
@@ -295,7 +295,7 @@ function inner_loop!(
 
         # check other stopping condition
         if optData.norm_∇F_ψ <= optData.η * (1 + abs(optData.F_θk))
-            if OptimizationMethods.obj!(progData, precomp, store, ψjk) <= optData.reference_value
+            if OptimizationMethods.obj(progData, precomp, store, ψjk) <= optData.reference_value
                 return j
             end
         end

--- a/src/methods/gd_watchdog_fixed_mnewton.jl
+++ b/src/methods/gd_watchdog_fixed_mnewton.jl
@@ -185,7 +185,7 @@ end
 Conduct the inner loop iteration, modifying `ψjk`, `optData`, and `store` in
     place. `ψjk` gets updated to be the terminal iterate of the inner loop.
     This inner loop function uses fixed step sizes with modified Newton
-    directions (see [OptimizationMethods.add_identity_until_pd!](@ref)).
+    directions.
 
 # Method
 

--- a/src/methods/line_search_helpers/backtracking.jl
+++ b/src/methods/line_search_helpers/backtracking.jl
@@ -48,11 +48,7 @@ where ``O_{k-1}`` is some reference value.
     Larger values correspond to stricter descent conditions, and
     smaller values correspond to looser descent conditions on `θk`.
 
-<<<<<<< HEAD
-## Optional Keyword Arguments
-=======
 # Optional Keyword Arguments
->>>>>>> main-v0.0.1
 
 - `max_iteration::Int64 = 100`, the maximum allowable iterations
     for the line search procedure. In the language above, when

--- a/src/methods/line_search_helpers/backtracking.jl
+++ b/src/methods/line_search_helpers/backtracking.jl
@@ -1,0 +1,186 @@
+# Date: 01/23/2025
+# Author: Christian Varner
+# Purpose: Implementation of a simple backtracking algorithm
+
+"""
+    backtracking!(θk::S, θkm1::S, F::Function, gkm1::S, step_direction::S,
+        reference_value::T, α::T, δ::T, ρ::T; max_iteration::Int64 = 100
+        ) where {T, S}
+
+Implementation of backtracking which modifies `θk` in place. This method
+    should be used for general step directions. If `gkm1` is the step direction
+    use the other `backtracking!(...)` method.
+
+# Reference(s)
+
+[Nocedal and Wright. "Numerical Optimization". 
+    Springer New York, NY.](@cite nocedal2006Numerical)
+
+# Method
+
+Let ``\\theta_{k-1}`` be the current iterate, and let 
+``\\alpha \\in \\mathbb{R}_{>0}``, ``\\delta \\in (0, 1)``, and
+``\\rho \\in (0, 1)``. Let ``d_k`` be the step direction, then
+``\\theta_k = \\theta_{k-1} - \\delta^t\\alpha d_k`` where 
+``t + 1 \\in \\mathbb{N}`` is the smallest such number satisfying
+
+```math
+    F(\\theta_k) \\leq O_{k-1} - \\rho\\delta^t\\alpha
+    \\dot F(\\theta_{k-1})^\\intercal d_k,
+```
+
+where ``O_{k-1}`` is some reference value. 
+
+# Arguments
+
+- `θk::S`, buffer array for the next iterate.
+- `θkm1::S`, current iterate the optimization algorithm.
+- `F::Function`, objective function. Should take in
+    a single argument and return the value of the 
+    objective at the input value.
+- `gkm1::S`, gradient value at `θkm1`.
+- `step_direction::S`, direction to move `θkm1` to form `θk`.
+- `reference_value::T`, value to check the objective function
+    at `θk` against.
+- `α::T`, initial step size.
+- `δ::T`, backtracking decrease factor.
+- `ρ::T`, factor involved in the acceptance criterion in `θk`.
+    Larger values correspond to stricter descent conditions, and
+    smaller values correspond to looser descent conditions on `θk`.
+
+## Optional Keyword Arguments
+
+- `max_iteration::Int64 = 100`, the maximum allowable iterations
+    for the line search procedure. In the language above, when
+    ``t`` is equal to `max_iteration` the algorithm will terminate.
+
+# Return
+
+- `backtracking_condition_satisfied::Bool`, whether the backtracking condition
+    is satisfied before the max iteration limit.
+"""
+function backtracking!(
+    θk::S,
+    θkm1::S,
+    F::Function,
+    gkm1::S,
+    step_direction::S,
+    reference_value::T,
+    α::T,
+    δ::T,
+    ρ::T;
+    max_iteration::Int64 = 100
+) where {T, S}
+
+    # initial step
+    t = 0
+    inner_prod_grad_by_direction = dot(gkm1, step_direction)
+    θk .= θkm1 - (δ^t * α) .* step_direction
+
+    # backtracking
+    backtracking_condition_satisfied = false
+    while (t < max_iteration) && (!backtracking_condition_satisfied)
+
+        if F(θk) > reference_value - ρ * (δ^t * α) * inner_prod_grad_by_direction
+            t += 1
+            θk .= θkm1 - (δ^t * α) .* step_direction
+        else
+            backtracking_condition_satisfied = true
+        end 
+    end
+
+    return backtracking_condition_satisfied
+end
+
+"""
+    backtracking!(θk::S, θkm1::S, F::Function, gkm1::S, norm_gkm1_squared::T,
+        reference_value::T, α::T, δ::T, ρ::T; max_iteration::Int64 = 100)
+        where {T, S}
+
+Implementation of backtracking which modifies `θk` in place. This method 
+    assumes that the step direction is `-gkm1`.
+
+# Reference(s)
+
+[Armijo, Larry. “Minimization of Functions Having Lipschitz Continuous 
+    First Partial Derivatives.” Pacific Journal of Mathematics 16.1 
+    (1966): 1–3. Pacific Journal of Mathematics. Web.](@cite armijo1966Minimization)
+
+[Nocedal and Wright. "Numerical Optimization". 
+    Springer New York, NY.](@cite nocedal2006Numerical)
+
+# Method
+
+Let ``\\theta_{k-1}`` be the current iterate, and let 
+``\\alpha \\in \\mathbb{R}_{>0}``, ``\\delta \\in (0, 1)``, and
+``\\rho \\in (0, 1)``. Let ``\\dot F(\\theta_{k-1})`` 
+be the step direction, then 
+``\\theta_k = \\theta_{k-1} - \\delta^t\\alpha \\dot F(\\theta_{k-1})`` where 
+``t + 1 \\in \\mathbb{N}`` is the smallest such number satisfying
+
+```math
+    F(\\theta_k) \\leq O_{k-1} - \\rho\\delta^t\\alpha
+    ||\\dot F(\\theta_{k-1})||_2^2,
+```
+
+where ``O_{k-1}`` is some reference value, and ``||\\cdot||_2`` is the L2-norm. 
+
+# Arguments
+
+- `θk::S`, buffer array for the next iterate.
+- `θkm1::S`, current iterate the optimization algorithm.
+- `F::Function`, objective function. Should take in
+    a single argument and return the value of the 
+    objective at the input value.
+- `gkm1::S`, gradient value at `θkm1`.
+- `norm_gkm1_squared::T`, norm squared for the value of `gkm1`.
+- `reference_value::T`, value to check the objective function
+    at `θk` against.
+- `α::T`, initial step size.
+- `δ::T`, backtracking decrease factor.
+- `ρ::T`, factor involved in the acceptance criterion in `θk`.
+    Larger values correspond to stricter descent conditions, and
+    smaller values correspond to looser descent conditions on `θk`.
+
+## Optional Keyword Arguments
+
+- `max_iteration::Int64 = 100`, the maximum allowable iterations
+    for the line search procedure. In the language above, when
+    ``t`` is equal to `max_iteration` the algorithm will terminate.
+
+# Return
+
+- `backtracking_condition_satisfied::Bool`, whether the backtracking condition
+    is satisfied before the max iteration limit.
+"""
+function backtracking!(
+    θk::S,
+    θkm1::S,
+    F::Function,
+    gkm1::S,
+    norm_gkm1_squared::T,
+    reference_value::T,
+    α::T,
+    δ::T,
+    ρ::T;
+    max_iteration::Int64 = 100
+) where {T, S}
+
+    # initial step
+    t = 0
+    θk .= θkm1 - (δ^t * α) .* gkm1
+
+    # backtracking
+    backtracking_condition_satisfied = false
+    while (t < max_iteration) && (!backtracking_condition_satisfied)
+
+        if F(θk) > reference_value - ρ * (δ^t * α) * norm_gkm1_squared 
+            t += 1
+            θk .= θkm1 - (δ^t * α) .* gkm1 
+        else
+            backtracking_condition_satisfied = true
+        end
+    end
+
+    return backtracking_condition_satisfied
+end

--- a/test/methods/gd_watchdog_fixed_mnewton.jl
+++ b/test/methods/gd_watchdog_fixed_mnewton.jl
@@ -4,7 +4,7 @@
 
 module TestWatchdogFixedModifiedNewton
 
-using Test, OptimizationMethods, Test, LinearAlgebra, CircularArrays
+using Test, OptimizationMethods, LinearAlgebra, CircularArrays
 
 @testset "Test WatchdogFixedMNewtonGD{T}" begin
 

--- a/test/methods/gd_watchdog_fixed_mnewton.jl
+++ b/test/methods/gd_watchdog_fixed_mnewton.jl
@@ -1,0 +1,507 @@
+# Date: 2025/05/12
+# Author: Christian Varner
+# Purpose: Test the modified newton globalized through watchdog
+
+module TestWatchdogFixedModifiedNewton
+
+using Test, OptimizationMethods, Test, LinearAlgebra, CircularArrays
+
+@testset "Test WatchdogFixedMNewtonGD{T}" begin
+
+    ############################################################################
+    # Test the structure definition and fields
+    ############################################################################
+
+    # test definition
+    @test isdefined(OptimizationMethods, :WatchdogFixedMNewtonGD)
+
+    # test field names
+    default_fields = [:name, :threshold, :max_iterations, :iter_hist, 
+        :grad_val_hist, :stop_iteration]
+    let fields = default_fields
+        for field in fields
+            @test field in fieldnames(WatchdogFixedMNewtonGD)
+        end
+    end # end of default tests
+
+    # test unique field names
+    unique_fields = [:F_θk, :∇F_θk, :norm_∇F_ψ, :β, :λ, 
+        :hessian_modification_max_iteration, :d0k, :α, :δ, :ρ,
+        :line_search_max_iterations, :max_distance_squared, :η, 
+        :inner_loop_max_iterations, :objective_hist, :reference_value,
+        :reference_value_index]
+    let fields = unique_fields
+        for field in fields
+            @test field in fieldnames(WatchdogFixedMNewtonGD)
+        end
+    end # test unique field names 
+
+    # test that I didn't miss anything
+    @test length(unique_fields) + length(default_fields) ==
+        length(fieldnames(WatchdogFixedMNewtonGD))
+
+    ############################################################################
+    # Test the error
+    ############################################################################
+    
+    ############################################################################
+    # Test the field types
+    ############################################################################
+
+    # define field types
+    field_types(::Type{T}) where {T} = 
+        [
+            (:name, String),
+            (:F_θk, T),
+            (:∇F_θk, Vector{T}),
+            (:norm_∇F_ψ, T),
+            (:β, T),
+            (:λ, T),
+            (:hessian_modification_max_iteration, Int64),
+            (:d0k, Vector{T}),
+            (:α, T),
+            (:δ, T),
+            (:ρ, T),
+            (:line_search_max_iterations, Int64),
+            (:max_distance_squared, T),
+            (:η, T),
+            (:inner_loop_max_iterations, Int64),
+            (:objective_hist, CircularVector{T, Vector{T}}),
+            (:reference_value, T),
+            (:reference_value_index, Int64),
+            (:threshold, T),
+            (:max_iterations, Int64),
+            (:iter_hist, Vector{Vector{T}}),
+            (:grad_val_hist, Vector{T}),
+            (:stop_iteration, Int64),
+        ]
+    real_types = [Float16, Float32, Float64]
+
+    let field_types = field_types, real_types = real_types
+        for T in real_types
+
+            # generate random arguments and struct
+            dim = rand(50:100)
+            x0 = randn(T, dim)
+            β = rand(T)
+            λ = rand(T)
+            hessian_modification_max_iteration = rand(1:100)
+            α = rand(T)
+            δ = rand(T)
+            ρ = rand(T)
+            line_search_max_iterations = rand(1:100)
+            η = rand(T)
+            inner_loop_max_iterations = rand(1:100)
+            window_size = rand(1:100)
+            threshold = rand(T)
+            max_iterations = rand(1:100)
+
+            optData = WatchdogFixedMNewtonGD(T;
+                x0 = x0,
+                β = β,
+                λ = λ, 
+                hessian_modification_max_iteration = hessian_modification_max_iteration,
+                α = α,
+                δ = δ,
+                ρ = ρ,
+                line_search_max_iterations = line_search_max_iterations,
+                η = η,
+                inner_loop_max_iterations = inner_loop_max_iterations,
+                window_size = window_size,
+                threshold = threshold,
+                max_iterations = max_iterations)
+
+            # test fields
+            for (field_symbol, field_type) in field_types(T)
+                @test field_type == typeof(getfield(optData, field_symbol))
+            end
+
+        end
+    end # test the types of the field
+    
+    ############################################################################
+    # Test the field initializations
+    ############################################################################
+
+    let real_types = real_types
+        for T in real_types
+
+            # generate random arguments and struct
+            dim = rand(50:100)
+            x0 = randn(T, dim)
+            β = rand(T)
+            λ = rand(T)
+            hessian_modification_max_iteration = rand(1:100)
+            α = rand(T)
+            δ = rand(T)
+            ρ = rand(T)
+            line_search_max_iterations = rand(1:100)
+            η = rand(T)
+            inner_loop_max_iterations = rand(1:100)
+            window_size = rand(1:100)
+            threshold = rand(T)
+            max_iterations = rand(1:100)
+
+            optData = WatchdogFixedMNewtonGD(T;
+                x0 = x0,
+                β = β,
+                λ = λ, 
+                hessian_modification_max_iteration = hessian_modification_max_iteration,
+                α = α,
+                δ = δ,
+                ρ = ρ,
+                line_search_max_iterations = line_search_max_iterations,
+                η = η,
+                inner_loop_max_iterations = inner_loop_max_iterations,
+                window_size = window_size,
+                threshold = threshold,
+                max_iterations = max_iterations)
+
+            # test fields - default
+            @test optData.threshold == threshold
+            @test optData.max_iterations == max_iterations
+            @test length(optData.iter_hist) == max_iterations + 1
+            @test length(optData.grad_val_hist) == max_iterations + 1
+            @test optData.stop_iteration == -1
+
+            # test buffer
+            @test length(optData.∇F_θk) == dim
+
+            # test modified newton helpers
+            @test optData.β == β
+            @test optData.λ == λ
+            @test optData.hessian_modification_max_iteration == 
+                hessian_modification_max_iteration
+            @test length(optData.d0k) == dim
+
+            # test line search parameters
+            @test optData.α == α
+            @test optData.δ == δ
+            @test optData.ρ == ρ
+            @test optData.line_search_max_iterations == line_search_max_iterations
+
+            # test watchdog stopping parameters
+            @test optData.η == η
+            @test optData.inner_loop_max_iterations == inner_loop_max_iterations
+
+            # test nonmonotone line search reference values
+            @test length(optData.objective_hist) == window_size
+            @test optData.reference_value == T(0)
+            @test optData.reference_value_index == -1
+
+        end
+    end # test the types of the field
+end
+
+@testset "Test WatchdogFixedMNewtonGD{T} Inner Loop" begin
+
+    # generate random arguments and struct
+    T = Float64
+    dim = rand(50:100)
+    x0 = randn(T, dim)
+    β = rand(T)
+    λ = rand(T)
+    hessian_modification_max_iteration = rand(1:100)
+    α = rand(T)
+    δ = rand(T)
+    ρ = rand(T)
+    line_search_max_iterations = rand(1:100)
+    η = rand(T)
+    inner_loop_max_iterations = rand(1:100)
+    window_size = rand(1:100)
+    threshold = rand(T)
+    max_iterations = rand(1:100)
+
+    # construct structure
+    optData = WatchdogFixedMNewtonGD(T;
+        x0 = x0,
+        β = β,
+        λ = λ, 
+        hessian_modification_max_iteration = hessian_modification_max_iteration,
+        α = α,
+        δ = δ,
+        ρ = ρ,
+        line_search_max_iterations = line_search_max_iterations,
+        η = η,
+        inner_loop_max_iterations = inner_loop_max_iterations,
+        window_size = window_size,
+        threshold = threshold,
+        max_iterations = max_iterations)
+
+    # problem 
+    progData = OptimizationMethods.LogisticRegression(Float64, nvar=dim)
+    precomp, store = OptimizationMethods.initialize(progData)
+
+    # test first event: max iterations 
+    let optData = optData, progData = progData, precomp = precomp, 
+        store = store, ψjk = copy(x0)
+        
+        k = rand(1:optData.max_iterations)
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = 0)
+
+        @test ψjk == x0
+        @test j == 0
+        @test optData.max_distance_squared == 0
+    end
+
+    # test second event: gradient and objective -- hessian works
+    let optData = optData, progData = progData, precomp = precomp,
+        store = store, ψjk = copy(x0)
+
+        k = rand(1:optData.max_iterations)
+
+        # reset values for the methd
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0) 
+
+        # set values to trigger the second event
+        optData.η = 1e16                        
+        optData.α = 1e-10
+
+        # run inner loop 
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = 100)
+
+        # test that the inner loop terminated after one iteration
+        @test j == 1
+
+        # test values
+        g0 = OptimizationMethods.grad(progData, x0) 
+        @test ψjk == x0 - optData.α * optData.d0k
+        @test optData.max_distance_squared == norm(ψjk - x0)^2
+        @test optData.norm_∇F_ψ ≈
+            norm(OptimizationMethods.grad(progData, ψjk))
+
+        H0 = OptimizationMethods.hess(progData, x0)
+        optData.λ = λ
+        res = OptimizationMethods.add_identity_until_pd!(H0;
+            λ = optData.λ,
+            β = optData.β,
+            max_iterations = 
+                optData.hessian_modification_max_iteration)
+        OptimizationMethods.lower_triangle_solve!(g0, H0')
+        OptimizationMethods.upper_triangle_solve!(g0, H0)
+
+        @test res[2]
+        @test optData.d0k ≈ g0
+    end
+
+    #  # test second event: gradient and objective -- not hessian
+    let optData = optData, progData = progData, precomp = precomp,
+        store = store, ψjk = copy(x0)
+
+        k = rand(1:optData.max_iterations)
+
+        # reset values for the methd
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0) 
+
+        # set values to trigger the second event
+        optData.η = 1e16                        
+        optData.α = 1e-10
+        optData.hessian_modification_max_iteration = 0
+
+        # run inner loop 
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = 100)
+
+        # test that the inner loop terminated after one iteration
+        @test j == 1
+
+        # test values
+        g0 = OptimizationMethods.grad(progData, x0) 
+        @test ψjk == x0 - optData.α * optData.d0k
+        @test optData.max_distance_squared == norm(ψjk - x0)^2
+        @test optData.norm_∇F_ψ ≈
+            norm(OptimizationMethods.grad(progData, ψjk))
+
+        H0 = OptimizationMethods.hess(progData, x0)
+        optData.λ = λ
+        res = OptimizationMethods.add_identity_until_pd!(H0;
+            λ = optData.λ,
+            β = optData.β,
+            max_iterations = 
+                optData.hessian_modification_max_iteration)
+
+        @test !res[2]
+        @test optData.d0k ≈ g0
+    end
+
+    # test random iteration -- hessian works
+    let optData = optData, progData = progData, precomp = precomp,
+        store = store, ψjk = copy(x0)
+
+        k = rand(1:optData.max_iterations)
+
+        # reset values for the methd
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0)
+        optData.α = optData.α
+        optData.λ = optData.λ
+        optData.β = optData.β
+        optData.hessian_modification_max_iteration = 100
+        optData.grad_val_hist[k] = norm(store.grad)
+        max_iterations = rand(2:100)
+
+        # run inner loop to get exit iterations
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = max_iterations)
+
+        # reset
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0)
+        optData.α = optData.α
+        optData.λ = optData.λ
+        optData.β = optData.β
+        optData.grad_val_hist[k] = norm(store.grad)
+        k = rand(1:optData.max_iterations)
+        optData.grad_val_hist[k] = norm(store.grad)
+
+        ψjk = copy(x0)
+
+        OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = j-1)
+
+        ψ_jm1_k = copy(ψjk)
+        maxdist = optData.max_distance_squared
+        g_jm1_k = copy(store.grad)
+        H_jm1_k = OptimizationMethods.hess(progData, ψ_jm1_k)
+
+        optData.λ = λ
+        res = OptimizationMethods.add_identity_until_pd!(H_jm1_k;
+            λ = optData.λ,
+            β = optData.β,
+            max_iterations = 
+                optData.hessian_modification_max_iteration)
+        OptimizationMethods.lower_triangle_solve!(g_jm1_k, H_jm1_k')
+        OptimizationMethods.upper_triangle_solve!(g_jm1_k, H_jm1_k)
+        step = optData.α * g_jm1_k
+
+        # reset
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0)
+        optData.α = optData.α
+        optData.λ = optData.λ
+        optData.β = optData.β
+        optData.grad_val_hist[k] = norm(store.grad)
+        k = rand(1:optData.max_iterations)
+        optData.grad_val_hist[k] = norm(store.grad)
+
+        ψjk = copy(x0)
+
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = j)
+
+        @test ψjk ≈ ψ_jm1_k - step
+        @test optData.max_distance_squared == max(norm(ψjk - x0)^2, maxdist)
+        @test optData.norm_∇F_ψ ≈
+            norm(OptimizationMethods.grad(progData, ψjk))
+        @test store.grad ≈ OptimizationMethods.grad(progData, ψjk)
+        @test store.hess ≈ OptimizationMethods.hess(progData, ψjk)
+        @test optData.λ ≈ res[1] / 2
+
+        g_jm1_k = OptimizationMethods.grad(progData, x0)
+        H_jm1_k = OptimizationMethods.hess(progData, x0)
+        optData.λ = λ
+        res = OptimizationMethods.add_identity_until_pd!(H_jm1_k;
+            λ = optData.λ,
+            β = optData.β,
+            max_iterations = 
+                optData.hessian_modification_max_iteration)
+        OptimizationMethods.lower_triangle_solve!(g_jm1_k, H_jm1_k')
+        OptimizationMethods.upper_triangle_solve!(g_jm1_k, H_jm1_k)
+
+        @test g_jm1_k ≈ optData.d0k
+    end
+
+    # test random iteration -- hessian fails
+    let optData = optData, progData = progData, precomp = precomp,
+        store = store, ψjk = copy(x0)
+
+        k = rand(1:optData.max_iterations)
+
+        # reset values for the methd
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0)
+        optData.α = optData.α
+        optData.λ = optData.λ
+        optData.β = optData.β
+        optData.hessian_modification_max_iteration = 0
+        optData.grad_val_hist[k] = norm(store.grad)
+        max_iterations = rand(2:100)
+
+        # run inner loop to get exit iterations
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = max_iterations)
+
+        # reset
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0)
+        optData.α = optData.α
+        optData.λ = optData.λ
+        optData.β = optData.β
+        optData.grad_val_hist[k] = norm(store.grad)
+        k = rand(1:optData.max_iterations)
+        optData.grad_val_hist[k] = norm(store.grad)
+
+        ψjk = copy(x0)
+
+        OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = j-1)
+
+        ψ_jm1_k = copy(ψjk)
+        maxdist = optData.max_distance_squared
+        g_jm1_k = copy(store.grad)
+        step = optData.α * g_jm1_k
+
+        # reset
+        optData.F_θk = OptimizationMethods.obj(progData, x0)
+        optData.reference_value = OptimizationMethods.obj(progData, x0)
+        OptimizationMethods.grad!(progData, precomp, store, x0)       
+        OptimizationMethods.hess!(progData, precomp, store, x0)
+        optData.α = optData.α
+        optData.λ = optData.λ
+        optData.β = optData.β
+        optData.grad_val_hist[k] = norm(store.grad)
+        k = rand(1:optData.max_iterations)
+        optData.grad_val_hist[k] = norm(store.grad)
+
+        ψjk = copy(x0)
+
+        j = OptimizationMethods.inner_loop!(ψjk, x0, optData, progData, precomp,
+            store, k; max_iterations = j)
+
+        @test ψjk ≈ ψ_jm1_k - step
+        @test optData.max_distance_squared == max(norm(ψjk - x0)^2, maxdist)
+        @test optData.norm_∇F_ψ ≈
+            norm(OptimizationMethods.grad(progData, ψjk))
+        @test store.grad ≈ OptimizationMethods.grad(progData, ψjk)
+        @test store.hess ≈ OptimizationMethods.hess(progData, ψjk)
+        @test optData.d0k ≈ OptimizationMethods.grad(progData, x0) 
+    end
+
+
+end # end of test for inner loop
+
+@testset "Test WatchdogFixedMNewtonGD{T} Method Monotone" begin
+end
+
+@testset "Test WatchdogFixedMNewtonGD{T} Method Nonmonotone" begin
+end
+
+end

--- a/test/test.txt
+++ b/test/test.txt
@@ -16,9 +16,7 @@ methods/gd_backtracking.jl
 methods/gd_fixed_nonmonotone_ls.jl
 methods/gd_non_sequential_armijo_adaptive.jl
 methods/gd_non_sequential_armijo_fixed.jl
-<<<<<<< HEAD
 methods/gd_watchdog_fixed_mnewton.jl
-=======
 methods/gd_fixed_step_watchdog_gd.jl
 methods/gd_fixed_nls_max_val_mnewton.jl
 methods/gd_safe_bb_nls_max_val.jl
@@ -26,7 +24,6 @@ methods/gd_fixed_nls_max_val_damped_bfgs.jl
 methods/gd_non_sequential_armijo_fixed_damped_bfgs.jl
 methods/gd_non_sequential_armijo_safe_bb.jl
 methods/gd_non_sequential_armijo_fixed_mnewton.jl
->>>>>>> main-v0.0.1
 problems/regression_helpers/link_functions.jl
 problems/regression_helpers/link_function_derivatives.jl
 problems/regression_helpers/variance_functions.jl

--- a/test/test.txt
+++ b/test/test.txt
@@ -14,6 +14,7 @@ methods/gd_nesterov_accelerated.jl
 methods/gd_diminishing.jl
 methods/gd_non_sequential_armijo_adaptive.jl
 methods/gd_non_sequential_armijo_fixed.jl
+methods/gd_watchdog_fixed_mnewton.jl
 problems/regression_helpers/link_functions.jl
 problems/regression_helpers/link_function_derivatives.jl
 problems/regression_helpers/variance_functions.jl


### PR DESCRIPTION
# Summary

Implementation of the modified newton method with fixed step size globalized through the watchdog technique.

# Method

Let $\\theta_{k}$ for $k + 1 \\in\\mathbb{N}$ be the $k^{th}$ iterate of the optimization algorithm. Let $\\alpha =$ `optData.α`.

Let $\\psi_0^k = \\theta_k$, then this method returns

$$
    \\psi_{j_k}^k = \\psi_0^k - \\sum_{i = 0}^{j_k-1} \\alpha_i^k d_i^k,
$$

where $j_k \\in \\mathbb{N}$ is the smallest iteration for which at least one of the conditions are satisfied: 

1. $j_k == $ `optData.inner_loop_max_iterations`
2. $\Vert \\dot F(\\psi_{j_k}^k) \Vert_2 \\leq \\eta (1 + |F(\\theta_k)|)$ and $\\Vert F(\\psi_{j_k}^k) \\Vert \\leq $ `optData.reference_value`.

The step direction $d_i^k$ is one of the following. Let $\\ddot F(\\psi_i^k)$ be the hessian matrix of $F$ at $\\psi_i^k$ for $i + 1 \\in \\mathbb{N}$ and $k + 1 \\in \\mathbb{N}$. Then, if the hessian modification routine successful modifies $\\ddot F(\\psi_i^k)$ to be positive definite, returning $H_i^k$, then

$$
    d_i^k = (H_i^k)^{-1} \\dot F(\\psi_i^k).
$$

When this routine is not successful, the method defaults to $d_i^k = \\dot F(\\psi_i^k)$.